### PR TITLE
security: address Dependabot alerts via npm overrides

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13914,6 +13914,21 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/semantic-release/node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/semantic-release/node_modules/wrap-ansi": {
       "version": "9.0.2",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
@@ -25710,6 +25725,14 @@
           "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
           "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
           "dev": true
+        },
+        "typescript": {
+          "version": "5.9.3",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+          "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+          "dev": true,
+          "optional": true,
+          "peer": true
         },
         "wrap-ansi": {
           "version": "9.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -444,11 +444,10 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz",
+      "integrity": "sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -487,28 +486,24 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
-      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.20.7.tgz",
+      "integrity": "sha512-PBPjs5BppzsGaxHQCDKnZ6Gd9s6xl8bBCluz3vEInLGRJmnZan4F6BYCeqtyXqkk4W5IlPmjK4JlOuZkpJ3xZA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0"
+        "@babel/template": "^7.20.7",
+        "@babel/traverse": "^7.20.7",
+        "@babel/types": "^7.20.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
-      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+      "version": "7.23.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.0.tgz",
+      "integrity": "sha512-vvPKKdMemU85V9WE/l5wZEmImpCtLqbnTvqDS2U1fJ96KrxoW7KrXhNsNCblQlg8Ck4b85yxdTyelsMUgFUXiw==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.29.0"
-      },
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -1690,25 +1685,26 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
-      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.7.tgz",
+      "integrity": "sha512-UF0tvkUtxwAgZ5W/KrkHf0Rn0fdnLDU9ScxBrEVNUprE/MzirjK4MJUX1/BVDv00Sv8cljtukVK1aky++X1SjQ==",
       "dev": true,
-      "license": "MIT",
+      "dependencies": {
+        "regenerator-runtime": "^0.13.11"
+      },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.15.tgz",
+      "integrity": "sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/code-frame": "^7.22.13",
+        "@babel/parser": "^7.22.15",
+        "@babel/types": "^7.22.15"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1736,14 +1732,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "version": "7.23.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.0.tgz",
+      "integrity": "sha512-0oIyUfKoI3mSqMvsxBdclDwxXKXAUA8v/apZbc+iSyARYou1o8ZGDxbUYyLFoW2arqS2jDGqJuZvv1d/io1axg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.22.5",
+        "@babel/helper-validator-identifier": "^7.22.20",
+        "to-fast-properties": "^2.0.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -4251,11 +4247,10 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -4726,6 +4721,17 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/cli-highlight/node_modules/yargs/node_modules/yargs-parser": {
+      "version": "13.1.2",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+      "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
       }
     },
     "node_modules/cli-table3": {
@@ -8540,12 +8546,26 @@
         "node": ">=8"
       }
     },
-    "node_modules/jest-snapshot/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+    "node_modules/jest-snapshot/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
       "dev": true,
-      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/jest-snapshot/node_modules/semver": {
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -8564,6 +8584,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/jest-snapshot/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "node_modules/jest-util": {
       "version": "29.3.1",
@@ -9855,13 +9881,12 @@
       "dev": true
     },
     "node_modules/micromatch": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
-      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "braces": "^3.0.3",
+        "braces": "^3.0.2",
         "picomatch": "^2.3.1"
       },
       "engines": {
@@ -9906,11 +9931,10 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -10077,11 +10101,10 @@
       "dev": true
     },
     "node_modules/normalize-package-data/node_modules/semver": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
       "dev": true,
-      "license": "ISC",
       "bin": {
         "semver": "bin/semver"
       }
@@ -10277,9 +10300,9 @@
       }
     },
     "node_modules/npm": {
-      "version": "11.13.0",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-11.13.0.tgz",
-      "integrity": "sha512-cRmhaghDWA1lFgl3Ug4/VxDJdPBK/U+tNtnrl9kXunFqhWw1x4xL5txkNn7qzPuVfvXOmXyjHpMwsuk2uisbkg==",
+      "version": "11.11.1",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-11.11.1.tgz",
+      "integrity": "sha512-asazCodkFdz1ReQzukyzS/DD77uGCIqUFeRG3gtaT8b9UR0ne1m9QOBuMgT72ij1rt7TRrOox4A1WzntMWIuEg==",
       "bundleDependencies": [
         "@isaacs/string-locale-compare",
         "@npmcli/arborist",
@@ -10348,18 +10371,10 @@
         "which"
       ],
       "dev": true,
-      "license": "Artistic-2.0",
-      "workspaces": [
-        "docs",
-        "smoke-tests",
-        "mock-globals",
-        "mock-registry",
-        "workspaces/*"
-      ],
       "dependencies": {
         "@isaacs/string-locale-compare": "^1.1.0",
-        "@npmcli/arborist": "^9.4.3",
-        "@npmcli/config": "^10.8.1",
+        "@npmcli/arborist": "^9.4.1",
+        "@npmcli/config": "^10.7.1",
         "@npmcli/fs": "^5.0.0",
         "@npmcli/map-workspaces": "^5.0.3",
         "@npmcli/metavuln-calculator": "^9.0.3",
@@ -10367,10 +10382,10 @@
         "@npmcli/promise-spawn": "^9.0.1",
         "@npmcli/redact": "^4.0.0",
         "@npmcli/run-script": "^10.0.4",
-        "@sigstore/tuf": "^4.0.2",
+        "@sigstore/tuf": "^4.0.1",
         "abbrev": "^4.0.0",
         "archy": "~1.0.0",
-        "cacache": "^20.0.4",
+        "cacache": "^20.0.3",
         "chalk": "^5.6.2",
         "ci-info": "^4.4.0",
         "fastest-levenshtein": "^1.0.16",
@@ -10380,24 +10395,24 @@
         "hosted-git-info": "^9.0.2",
         "ini": "^6.0.0",
         "init-package-json": "^8.2.5",
-        "is-cidr": "^6.0.4",
+        "is-cidr": "^6.0.3",
         "json-parse-even-better-errors": "^5.0.0",
         "libnpmaccess": "^10.0.3",
-        "libnpmdiff": "^8.1.6",
-        "libnpmexec": "^10.2.6",
-        "libnpmfund": "^7.0.20",
+        "libnpmdiff": "^8.1.4",
+        "libnpmexec": "^10.2.4",
+        "libnpmfund": "^7.0.18",
         "libnpmorg": "^8.0.1",
-        "libnpmpack": "^9.1.6",
+        "libnpmpack": "^9.1.4",
         "libnpmpublish": "^11.1.3",
         "libnpmsearch": "^9.0.1",
         "libnpmteam": "^8.0.2",
         "libnpmversion": "^8.0.3",
-        "make-fetch-happen": "^15.0.5",
-        "minimatch": "^10.2.5",
+        "make-fetch-happen": "^15.0.4",
+        "minimatch": "^10.2.4",
         "minipass": "^7.1.3",
         "minipass-pipeline": "^1.2.4",
         "ms": "^2.1.2",
-        "node-gyp": "^12.3.0",
+        "node-gyp": "^12.2.0",
         "nopt": "^9.0.0",
         "npm-audit-report": "^7.0.0",
         "npm-install-checks": "^8.0.0",
@@ -10416,7 +10431,7 @@
         "spdx-expression-parse": "^4.0.0",
         "ssri": "^13.0.1",
         "supports-color": "^10.2.2",
-        "tar": "^7.5.13",
+        "tar": "^7.5.11",
         "text-table": "~0.2.0",
         "tiny-relative-date": "^2.0.2",
         "treeverse": "^3.0.0",
@@ -10462,12 +10477,24 @@
       }
     },
     "node_modules/npm/node_modules/@gar/promise-retry": {
-      "version": "1.0.3",
+      "version": "1.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/@gar/promise-retry/node_modules/retry": {
+      "version": "0.13.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
-        "node": "^20.17.0 || >=22.9.0"
+        "node": ">= 4"
       }
     },
     "node_modules/npm/node_modules/@isaacs/fs-minipass": {
@@ -10505,7 +10532,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/arborist": {
-      "version": "9.4.3",
+      "version": "9.4.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10553,7 +10580,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/config": {
-      "version": "10.8.1",
+      "version": "10.7.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10747,7 +10774,7 @@
       }
     },
     "node_modules/npm/node_modules/@sigstore/core": {
-      "version": "3.2.0",
+      "version": "3.1.0",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -10756,7 +10783,7 @@
       }
     },
     "node_modules/npm/node_modules/@sigstore/protobuf-specs": {
-      "version": "0.5.1",
+      "version": "0.5.0",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -10765,24 +10792,24 @@
       }
     },
     "node_modules/npm/node_modules/@sigstore/sign": {
-      "version": "4.1.1",
+      "version": "4.1.0",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@gar/promise-retry": "^1.0.2",
         "@sigstore/bundle": "^4.0.0",
-        "@sigstore/core": "^3.2.0",
+        "@sigstore/core": "^3.1.0",
         "@sigstore/protobuf-specs": "^0.5.0",
-        "make-fetch-happen": "^15.0.4",
-        "proc-log": "^6.1.0"
+        "make-fetch-happen": "^15.0.3",
+        "proc-log": "^6.1.0",
+        "promise-retry": "^2.0.1"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/@sigstore/tuf": {
-      "version": "4.0.2",
+      "version": "4.0.1",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -10898,7 +10925,7 @@
       }
     },
     "node_modules/npm/node_modules/brace-expansion": {
-      "version": "5.0.5",
+      "version": "5.0.4",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10910,7 +10937,7 @@
       }
     },
     "node_modules/npm/node_modules/cacache": {
-      "version": "20.0.4",
+      "version": "20.0.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10924,7 +10951,8 @@
         "minipass-flush": "^1.0.5",
         "minipass-pipeline": "^1.2.4",
         "p-map": "^7.0.2",
-        "ssri": "^13.0.0"
+        "ssri": "^13.0.0",
+        "unique-filename": "^5.0.0"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -10967,7 +10995,7 @@
       }
     },
     "node_modules/npm/node_modules/cidr-regex": {
-      "version": "5.0.4",
+      "version": "5.0.3",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
@@ -11023,7 +11051,7 @@
       }
     },
     "node_modules/npm/node_modules/diff": {
-      "version": "8.0.4",
+      "version": "8.0.3",
       "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
@@ -11043,6 +11071,7 @@
     "node_modules/npm/node_modules/err-code": {
       "version": "2.0.3",
       "dev": true,
+      "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/exponential-backoff": {
@@ -11171,6 +11200,7 @@
     "node_modules/npm/node_modules/imurmurhash": {
       "version": "0.1.4",
       "dev": true,
+      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
@@ -11212,12 +11242,12 @@
       }
     },
     "node_modules/npm/node_modules/is-cidr": {
-      "version": "6.0.4",
+      "version": "6.0.3",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "cidr-regex": "^5.0.4"
+        "cidr-regex": "^5.0.1"
       },
       "engines": {
         "node": ">=20"
@@ -11285,12 +11315,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmdiff": {
-      "version": "8.1.6",
+      "version": "8.1.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.4.3",
+        "@npmcli/arborist": "^9.4.1",
         "@npmcli/installed-package-contents": "^4.0.0",
         "binary-extensions": "^3.0.0",
         "diff": "^8.0.2",
@@ -11304,13 +11334,13 @@
       }
     },
     "node_modules/npm/node_modules/libnpmexec": {
-      "version": "10.2.6",
+      "version": "10.2.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "@gar/promise-retry": "^1.0.0",
-        "@npmcli/arborist": "^9.4.3",
+        "@npmcli/arborist": "^9.4.1",
         "@npmcli/package-json": "^7.0.0",
         "@npmcli/run-script": "^10.0.0",
         "ci-info": "^4.0.0",
@@ -11327,12 +11357,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmfund": {
-      "version": "7.0.20",
+      "version": "7.0.18",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.4.3"
+        "@npmcli/arborist": "^9.4.1"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -11352,12 +11382,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmpack": {
-      "version": "9.1.6",
+      "version": "9.1.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.4.3",
+        "@npmcli/arborist": "^9.4.1",
         "@npmcli/run-script": "^10.0.0",
         "npm-package-arg": "^13.0.0",
         "pacote": "^21.0.2"
@@ -11427,7 +11457,7 @@
       }
     },
     "node_modules/npm/node_modules/lru-cache": {
-      "version": "11.3.5",
+      "version": "11.2.6",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
@@ -11436,14 +11466,13 @@
       }
     },
     "node_modules/npm/node_modules/make-fetch-happen": {
-      "version": "15.0.5",
+      "version": "15.0.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "@gar/promise-retry": "^1.0.0",
         "@npmcli/agent": "^4.0.0",
-        "@npmcli/redact": "^4.0.0",
         "cacache": "^20.0.1",
         "http-cache-semantics": "^4.1.1",
         "minipass": "^7.0.2",
@@ -11459,12 +11488,12 @@
       }
     },
     "node_modules/npm/node_modules/minimatch": {
-      "version": "10.2.5",
+      "version": "10.2.4",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.5"
+        "brace-expansion": "^5.0.2"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -11512,16 +11541,34 @@
       }
     },
     "node_modules/npm/node_modules/minipass-flush": {
-      "version": "1.0.6",
+      "version": "1.0.5",
       "dev": true,
       "inBundle": true,
-      "license": "BlueOak-1.0.0",
+      "license": "ISC",
       "dependencies": {
-        "minipass": "^7.1.3"
+        "minipass": "^3.0.0"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
+        "node": ">= 8"
       }
+    },
+    "node_modules/npm/node_modules/minipass-flush/node_modules/minipass": {
+      "version": "3.3.6",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/npm/node_modules/minipass-flush/node_modules/yallist": {
+      "version": "4.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
     },
     "node_modules/npm/node_modules/minipass-pipeline": {
       "version": "1.2.4",
@@ -11602,7 +11649,7 @@
       }
     },
     "node_modules/npm/node_modules/node-gyp": {
-      "version": "12.3.0",
+      "version": "12.2.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11610,12 +11657,12 @@
         "env-paths": "^2.2.0",
         "exponential-backoff": "^3.1.1",
         "graceful-fs": "^4.2.6",
+        "make-fetch-happen": "^15.0.0",
         "nopt": "^9.0.0",
         "proc-log": "^6.0.0",
         "semver": "^7.3.5",
         "tar": "^7.5.4",
         "tinyglobby": "^0.2.12",
-        "undici": "^6.25.0",
         "which": "^6.0.0"
       },
       "bin": {
@@ -11891,6 +11938,7 @@
     "node_modules/npm/node_modules/promise-retry": {
       "version": "2.0.1",
       "dev": true,
+      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "err-code": "^2.0.2",
@@ -11944,6 +11992,7 @@
     "node_modules/npm/node_modules/retry": {
       "version": "0.12.0",
       "dev": true,
+      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -12082,7 +12131,7 @@
       }
     },
     "node_modules/npm/node_modules/tar": {
-      "version": "7.5.13",
+      "version": "7.5.11",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
@@ -12110,13 +12159,13 @@
       "license": "MIT"
     },
     "node_modules/npm/node_modules/tinyglobby": {
-      "version": "0.2.16",
+      "version": "0.2.15",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.4"
+        "picomatch": "^4.0.3"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -12143,7 +12192,7 @@
       }
     },
     "node_modules/npm/node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.4",
+      "version": "4.0.3",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -12177,18 +12226,10 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
-    "node_modules/npm/node_modules/undici": {
-      "version": "6.25.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.17"
-      }
-    },
     "node_modules/npm/node_modules/unique-filename": {
       "version": "5.0.0",
       "dev": true,
+      "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "unique-slug": "^6.0.0"
@@ -12200,6 +12241,7 @@
     "node_modules/npm/node_modules/unique-slug": {
       "version": "6.0.0",
       "dev": true,
+      "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "imurmurhash": "^0.1.4"
@@ -13219,6 +13261,12 @@
         "node": ">=4"
       }
     },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "dev": true
+    },
     "node_modules/regenerator-transform": {
       "version": "0.15.1",
       "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.15.1.tgz",
@@ -13900,12 +13948,22 @@
         "node": "^20.19.0 || ^22.12.0 || >=23"
       }
     },
-    "node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+    "node_modules/semantic-release/node_modules/yargs/node_modules/yargs-parser": {
+      "version": "13.1.2",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+      "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
       "dev": true,
       "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true,
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -14693,6 +14751,15 @@
       "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
       "dev": true
     },
+    "node_modules/to-fast-properties": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -14772,18 +14839,38 @@
         }
       }
     },
-    "node_modules/ts-jest/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+    "node_modules/ts-jest/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
       "dev": true,
-      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ts-jest/node_modules/semver": {
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
       "bin": {
         "semver": "bin/semver.js"
       },
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/ts-jest/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "node_modules/ts-jest/node_modules/yargs-parser": {
       "version": "21.1.1",
@@ -15046,11 +15133,10 @@
       }
     },
     "node_modules/update-notifier/node_modules/semver": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
       "dev": true,
-      "license": "ISC",
       "bin": {
         "semver": "bin/semver"
       }
@@ -15245,11 +15331,10 @@
       }
     },
     "node_modules/windows-release/node_modules/cross-spawn": {
-      "version": "6.0.6",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.6.tgz",
-      "integrity": "sha512-VqCUuhcd1iB+dsv8gxPttb5iZh/D0iubSP21g36KXdEuf6I5JiioesUVjpCdHV9MZRUfVFlvwtIUyPfxo5trtw==",
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "nice-try": "^1.0.4",
         "path-key": "^2.0.1",
@@ -15331,11 +15416,10 @@
       }
     },
     "node_modules/windows-release/node_modules/semver": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
       "dev": true,
-      "license": "ISC",
       "bin": {
         "semver": "bin/semver"
       }
@@ -15877,9 +15961,9 @@
       }
     },
     "@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz",
+      "integrity": "sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==",
       "dev": true
     },
     "@babel/helper-validator-identifier": {
@@ -15907,23 +15991,21 @@
       }
     },
     "@babel/helpers": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
-      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.20.7.tgz",
+      "integrity": "sha512-PBPjs5BppzsGaxHQCDKnZ6Gd9s6xl8bBCluz3vEInLGRJmnZan4F6BYCeqtyXqkk4W5IlPmjK4JlOuZkpJ3xZA==",
       "dev": true,
       "requires": {
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0"
+        "@babel/template": "^7.20.7",
+        "@babel/traverse": "^7.20.7",
+        "@babel/types": "^7.20.7"
       }
     },
     "@babel/parser": {
-      "version": "7.29.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
-      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
-      "dev": true,
-      "requires": {
-        "@babel/types": "^7.29.0"
-      }
+      "version": "7.23.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.0.tgz",
+      "integrity": "sha512-vvPKKdMemU85V9WE/l5wZEmImpCtLqbnTvqDS2U1fJ96KrxoW7KrXhNsNCblQlg8Ck4b85yxdTyelsMUgFUXiw==",
+      "dev": true
     },
     "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
       "version": "7.18.6",
@@ -16709,20 +16791,23 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
-      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
-      "dev": true
-    },
-    "@babel/template": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.7.tgz",
+      "integrity": "sha512-UF0tvkUtxwAgZ5W/KrkHf0Rn0fdnLDU9ScxBrEVNUprE/MzirjK4MJUX1/BVDv00Sv8cljtukVK1aky++X1SjQ==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "regenerator-runtime": "^0.13.11"
+      }
+    },
+    "@babel/template": {
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.15.tgz",
+      "integrity": "sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.22.13",
+        "@babel/parser": "^7.22.15",
+        "@babel/types": "^7.22.15"
       }
     },
     "@babel/traverse": {
@@ -16744,13 +16829,14 @@
       }
     },
     "@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "version": "7.23.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.0.tgz",
+      "integrity": "sha512-0oIyUfKoI3mSqMvsxBdclDwxXKXAUA8v/apZbc+iSyARYou1o8ZGDxbUYyLFoW2arqS2jDGqJuZvv1d/io1axg==",
       "dev": true,
       "requires": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.22.5",
+        "@babel/helper-validator-identifier": "^7.22.20",
+        "to-fast-properties": "^2.0.0"
       }
     },
     "@bcoe/v8-coverage": {
@@ -17837,7 +17923,7 @@
         "lodash-es": "^4.17.21",
         "nerf-dart": "^1.0.0",
         "normalize-url": "^9.0.0",
-        "npm": "^11.13.0",
+        "npm": "^11.6.2",
         "rc": "^1.2.8",
         "read-pkg": "^10.0.0",
         "registry-auth-token": "^5.0.0",
@@ -18694,9 +18780,9 @@
       }
     },
     "brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
@@ -19032,6 +19118,18 @@
             "string-width": "^4.2.0",
             "y18n": "^5.0.5",
             "yargs-parser": "^13.1.2"
+          },
+          "dependencies": {
+            "yargs-parser": {
+              "version": "13.1.2",
+              "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+              "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+              "dev": true,
+              "requires": {
+                "camelcase": "^5.0.0",
+                "decamelize": "^1.2.0"
+              }
+            }
           }
         }
       }
@@ -21838,11 +21936,23 @@
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
         "semver": {
-          "version": "7.7.4",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-          "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-          "dev": true
+          "version": "7.3.8",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
         },
         "supports-color": {
           "version": "7.2.0",
@@ -21852,6 +21962,12 @@
           "requires": {
             "has-flag": "^4.0.0"
           }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
         }
       }
     },
@@ -22828,12 +22944,12 @@
       "dev": true
     },
     "micromatch": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
-      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
       "dev": true,
       "requires": {
-        "braces": "^3.0.3",
+        "braces": "^3.0.2",
         "picomatch": "^4.0.4"
       }
     },
@@ -22856,9 +22972,9 @@
       "dev": true
     },
     "minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
@@ -22996,9 +23112,9 @@
           "dev": true
         },
         "semver": {
-          "version": "5.7.2",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-          "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
           "dev": true
         }
       }
@@ -23147,14 +23263,14 @@
       }
     },
     "npm": {
-      "version": "11.13.0",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-11.13.0.tgz",
-      "integrity": "sha512-cRmhaghDWA1lFgl3Ug4/VxDJdPBK/U+tNtnrl9kXunFqhWw1x4xL5txkNn7qzPuVfvXOmXyjHpMwsuk2uisbkg==",
+      "version": "11.11.1",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-11.11.1.tgz",
+      "integrity": "sha512-asazCodkFdz1ReQzukyzS/DD77uGCIqUFeRG3gtaT8b9UR0ne1m9QOBuMgT72ij1rt7TRrOox4A1WzntMWIuEg==",
       "dev": true,
       "requires": {
         "@isaacs/string-locale-compare": "^1.1.0",
-        "@npmcli/arborist": "^9.4.3",
-        "@npmcli/config": "^10.8.1",
+        "@npmcli/arborist": "^9.4.1",
+        "@npmcli/config": "^10.7.1",
         "@npmcli/fs": "^5.0.0",
         "@npmcli/map-workspaces": "^5.0.3",
         "@npmcli/metavuln-calculator": "^9.0.3",
@@ -23162,10 +23278,10 @@
         "@npmcli/promise-spawn": "^9.0.1",
         "@npmcli/redact": "^4.0.0",
         "@npmcli/run-script": "^10.0.4",
-        "@sigstore/tuf": "^4.0.2",
+        "@sigstore/tuf": "^4.0.1",
         "abbrev": "^4.0.0",
         "archy": "~1.0.0",
-        "cacache": "^20.0.4",
+        "cacache": "^20.0.3",
         "chalk": "^5.6.2",
         "ci-info": "^4.4.0",
         "fastest-levenshtein": "^1.0.16",
@@ -23175,24 +23291,24 @@
         "hosted-git-info": "^9.0.2",
         "ini": "^6.0.0",
         "init-package-json": "^8.2.5",
-        "is-cidr": "^6.0.4",
+        "is-cidr": "^6.0.3",
         "json-parse-even-better-errors": "^5.0.0",
         "libnpmaccess": "^10.0.3",
-        "libnpmdiff": "^8.1.6",
-        "libnpmexec": "^10.2.6",
-        "libnpmfund": "^7.0.20",
+        "libnpmdiff": "^8.1.4",
+        "libnpmexec": "^10.2.4",
+        "libnpmfund": "^7.0.18",
         "libnpmorg": "^8.0.1",
-        "libnpmpack": "^9.1.6",
+        "libnpmpack": "^9.1.4",
         "libnpmpublish": "^11.1.3",
         "libnpmsearch": "^9.0.1",
         "libnpmteam": "^8.0.2",
         "libnpmversion": "^8.0.3",
-        "make-fetch-happen": "^15.0.5",
-        "minimatch": "^10.2.5",
+        "make-fetch-happen": "^15.0.4",
+        "minimatch": "^10.2.4",
         "minipass": "^7.1.3",
         "minipass-pipeline": "^1.2.4",
         "ms": "^2.1.2",
-        "node-gyp": "^12.3.0",
+        "node-gyp": "^12.2.0",
         "nopt": "^9.0.0",
         "npm-audit-report": "^7.0.0",
         "npm-install-checks": "^8.0.0",
@@ -23211,7 +23327,7 @@
         "spdx-expression-parse": "^4.0.0",
         "ssri": "^13.0.1",
         "supports-color": "^10.2.2",
-        "tar": "^7.5.13",
+        "tar": "^7.5.11",
         "text-table": "~0.2.0",
         "tiny-relative-date": "^2.0.2",
         "treeverse": "^3.0.0",
@@ -23220,9 +23336,19 @@
       },
       "dependencies": {
         "@gar/promise-retry": {
-          "version": "1.0.3",
+          "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "retry": "^0.13.1"
+          },
+          "dependencies": {
+            "retry": {
+              "version": "0.13.1",
+              "bundled": true,
+              "dev": true
+            }
+          }
         },
         "@isaacs/fs-minipass": {
           "version": "4.0.1",
@@ -23250,7 +23376,7 @@
           }
         },
         "@npmcli/arborist": {
-          "version": "9.4.3",
+          "version": "9.4.1",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -23291,7 +23417,7 @@
           }
         },
         "@npmcli/config": {
-          "version": "10.8.1",
+          "version": "10.7.1",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -23426,30 +23552,30 @@
           }
         },
         "@sigstore/core": {
-          "version": "3.2.0",
+          "version": "3.1.0",
           "bundled": true,
           "dev": true
         },
         "@sigstore/protobuf-specs": {
-          "version": "0.5.1",
+          "version": "0.5.0",
           "bundled": true,
           "dev": true
         },
         "@sigstore/sign": {
-          "version": "4.1.1",
+          "version": "4.1.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@gar/promise-retry": "^1.0.2",
             "@sigstore/bundle": "^4.0.0",
-            "@sigstore/core": "^3.2.0",
+            "@sigstore/core": "^3.1.0",
             "@sigstore/protobuf-specs": "^0.5.0",
-            "make-fetch-happen": "^15.0.4",
-            "proc-log": "^6.1.0"
+            "make-fetch-happen": "^15.0.3",
+            "proc-log": "^6.1.0",
+            "promise-retry": "^2.0.1"
           }
         },
         "@sigstore/tuf": {
-          "version": "4.0.2",
+          "version": "4.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -23524,7 +23650,7 @@
           "dev": true
         },
         "brace-expansion": {
-          "version": "5.0.5",
+          "version": "5.0.4",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -23532,7 +23658,7 @@
           }
         },
         "cacache": {
-          "version": "20.0.4",
+          "version": "20.0.3",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -23545,7 +23671,8 @@
             "minipass-flush": "^1.0.5",
             "minipass-pipeline": "^1.2.4",
             "p-map": "^7.0.2",
-            "ssri": "^13.0.0"
+            "ssri": "^13.0.0",
+            "unique-filename": "^5.0.0"
           }
         },
         "chalk": {
@@ -23564,7 +23691,7 @@
           "dev": true
         },
         "cidr-regex": {
-          "version": "5.0.4",
+          "version": "5.0.3",
           "bundled": true,
           "dev": true
         },
@@ -23592,7 +23719,7 @@
           }
         },
         "diff": {
-          "version": "8.0.4",
+          "version": "8.0.3",
           "bundled": true,
           "dev": true
         },
@@ -23603,6 +23730,7 @@
         },
         "err-code": {
           "version": "2.0.3",
+          "bundled": true,
           "dev": true
         },
         "exponential-backoff": {
@@ -23688,6 +23816,7 @@
         },
         "imurmurhash": {
           "version": "0.1.4",
+          "bundled": true,
           "dev": true
         },
         "ini": {
@@ -23714,11 +23843,11 @@
           "dev": true
         },
         "is-cidr": {
-          "version": "6.0.4",
+          "version": "6.0.3",
           "bundled": true,
           "dev": true,
           "requires": {
-            "cidr-regex": "^5.0.4"
+            "cidr-regex": "^5.0.1"
           }
         },
         "isexe": {
@@ -23761,11 +23890,11 @@
           }
         },
         "libnpmdiff": {
-          "version": "8.1.6",
+          "version": "8.1.4",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@npmcli/arborist": "^9.4.3",
+            "@npmcli/arborist": "^9.4.1",
             "@npmcli/installed-package-contents": "^4.0.0",
             "binary-extensions": "^3.0.0",
             "diff": "^8.0.2",
@@ -23776,12 +23905,12 @@
           }
         },
         "libnpmexec": {
-          "version": "10.2.6",
+          "version": "10.2.4",
           "bundled": true,
           "dev": true,
           "requires": {
             "@gar/promise-retry": "^1.0.0",
-            "@npmcli/arborist": "^9.4.3",
+            "@npmcli/arborist": "^9.4.1",
             "@npmcli/package-json": "^7.0.0",
             "@npmcli/run-script": "^10.0.0",
             "ci-info": "^4.0.0",
@@ -23795,11 +23924,11 @@
           }
         },
         "libnpmfund": {
-          "version": "7.0.20",
+          "version": "7.0.18",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@npmcli/arborist": "^9.4.3"
+            "@npmcli/arborist": "^9.4.1"
           }
         },
         "libnpmorg": {
@@ -23812,11 +23941,11 @@
           }
         },
         "libnpmpack": {
-          "version": "9.1.6",
+          "version": "9.1.4",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@npmcli/arborist": "^9.4.3",
+            "@npmcli/arborist": "^9.4.1",
             "@npmcli/run-script": "^10.0.0",
             "npm-package-arg": "^13.0.0",
             "pacote": "^21.0.2"
@@ -23867,18 +23996,17 @@
           }
         },
         "lru-cache": {
-          "version": "11.3.5",
+          "version": "11.2.6",
           "bundled": true,
           "dev": true
         },
         "make-fetch-happen": {
-          "version": "15.0.5",
+          "version": "15.0.4",
           "bundled": true,
           "dev": true,
           "requires": {
             "@gar/promise-retry": "^1.0.0",
             "@npmcli/agent": "^4.0.0",
-            "@npmcli/redact": "^4.0.0",
             "cacache": "^20.0.1",
             "http-cache-semantics": "^4.1.1",
             "minipass": "^7.0.2",
@@ -23891,11 +24019,11 @@
           }
         },
         "minimatch": {
-          "version": "10.2.5",
+          "version": "10.2.4",
           "bundled": true,
           "dev": true,
           "requires": {
-            "brace-expansion": "^5.0.5"
+            "brace-expansion": "^5.0.2"
           }
         },
         "minipass": {
@@ -23923,11 +24051,26 @@
           }
         },
         "minipass-flush": {
-          "version": "1.0.6",
+          "version": "1.0.5",
           "bundled": true,
           "dev": true,
           "requires": {
-            "minipass": "^7.1.3"
+            "minipass": "^3.0.0"
+          },
+          "dependencies": {
+            "minipass": {
+              "version": "3.3.6",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "yallist": "^4.0.0"
+              }
+            },
+            "yallist": {
+              "version": "4.0.0",
+              "bundled": true,
+              "dev": true
+            }
           }
         },
         "minipass-pipeline": {
@@ -23985,19 +24128,19 @@
           "dev": true
         },
         "node-gyp": {
-          "version": "12.3.0",
+          "version": "12.2.0",
           "bundled": true,
           "dev": true,
           "requires": {
             "env-paths": "^2.2.0",
             "exponential-backoff": "^3.1.1",
             "graceful-fs": "^4.2.6",
+            "make-fetch-happen": "^15.0.0",
             "nopt": "^9.0.0",
             "proc-log": "^6.0.0",
             "semver": "^7.3.5",
             "tar": "^7.5.4",
             "tinyglobby": "^0.2.12",
-            "undici": "^6.25.0",
             "which": "^6.0.0"
           }
         },
@@ -24174,6 +24317,7 @@
         },
         "promise-retry": {
           "version": "2.0.1",
+          "bundled": true,
           "dev": true,
           "requires": {
             "err-code": "^2.0.2",
@@ -24208,6 +24352,7 @@
         },
         "retry": {
           "version": "0.12.0",
+          "bundled": true,
           "dev": true
         },
         "safer-buffer": {
@@ -24296,7 +24441,7 @@
           "dev": true
         },
         "tar": {
-          "version": "7.5.13",
+          "version": "7.5.11",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -24318,7 +24463,7 @@
           "dev": true
         },
         "tinyglobby": {
-          "version": "0.2.16",
+          "version": "0.2.15",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -24333,7 +24478,7 @@
               "requires": {}
             },
             "picomatch": {
-              "version": "4.0.4",
+              "version": "4.0.3",
               "bundled": true,
               "dev": true
             }
@@ -24354,13 +24499,9 @@
             "make-fetch-happen": "^15.0.1"
           }
         },
-        "undici": {
-          "version": "6.25.0",
-          "bundled": true,
-          "dev": true
-        },
         "unique-filename": {
           "version": "5.0.0",
+          "bundled": true,
           "dev": true,
           "requires": {
             "unique-slug": "^6.0.0"
@@ -24368,6 +24509,7 @@
         },
         "unique-slug": {
           "version": "6.0.0",
+          "bundled": true,
           "dev": true,
           "requires": {
             "imurmurhash": "^0.1.4"
@@ -25122,6 +25264,12 @@
         "regenerate": "^1.4.2"
       }
     },
+    "regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "dev": true
+    },
     "regenerator-transform": {
       "version": "0.15.1",
       "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.15.1.tgz",
@@ -25586,6 +25734,18 @@
             "string-width": "^7.2.0",
             "y18n": "^5.0.5",
             "yargs-parser": "^13.1.2"
+          },
+          "dependencies": {
+            "yargs-parser": {
+              "version": "13.1.2",
+              "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+              "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+              "dev": true,
+              "requires": {
+                "camelcase": "^5.0.0",
+                "decamelize": "^1.2.0"
+              }
+            }
           }
         }
       }
@@ -25601,9 +25761,9 @@
       }
     },
     "semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
       "dev": true
     },
     "semver-regex": {
@@ -26199,6 +26359,12 @@
       "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
       "dev": true
     },
+    "to-fast-properties": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
+      "dev": true
+    },
     "to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -26242,10 +26408,28 @@
         "yargs-parser": "^13.1.2"
       },
       "dependencies": {
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
         "semver": {
-          "version": "7.7.4",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-          "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+          "version": "7.3.8",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
           "dev": true
         },
         "yargs-parser": {
@@ -26421,9 +26605,9 @@
           }
         },
         "semver": {
-          "version": "5.7.2",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-          "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
           "dev": true
         },
         "semver-diff": {
@@ -26581,9 +26765,9 @@
       },
       "dependencies": {
         "cross-spawn": {
-          "version": "6.0.6",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.6.tgz",
-          "integrity": "sha512-VqCUuhcd1iB+dsv8gxPttb5iZh/D0iubSP21g36KXdEuf6I5JiioesUVjpCdHV9MZRUfVFlvwtIUyPfxo5trtw==",
+          "version": "6.0.5",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
           "dev": true,
           "requires": {
             "nice-try": "^1.0.4",
@@ -26645,9 +26829,9 @@
           "dev": true
         },
         "semver": {
-          "version": "5.7.2",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-          "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
           "dev": true
         },
         "shebang-command": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -444,10 +444,11 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz",
-      "integrity": "sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -486,24 +487,28 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.20.7",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.20.7.tgz",
-      "integrity": "sha512-PBPjs5BppzsGaxHQCDKnZ6Gd9s6xl8bBCluz3vEInLGRJmnZan4F6BYCeqtyXqkk4W5IlPmjK4JlOuZkpJ3xZA==",
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.20.7",
-        "@babel/traverse": "^7.20.7",
-        "@babel/types": "^7.20.7"
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.0.tgz",
-      "integrity": "sha512-vvPKKdMemU85V9WE/l5wZEmImpCtLqbnTvqDS2U1fJ96KrxoW7KrXhNsNCblQlg8Ck4b85yxdTyelsMUgFUXiw==",
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
       "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -1685,26 +1690,25 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.20.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.7.tgz",
-      "integrity": "sha512-UF0tvkUtxwAgZ5W/KrkHf0Rn0fdnLDU9ScxBrEVNUprE/MzirjK4MJUX1/BVDv00Sv8cljtukVK1aky++X1SjQ==",
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
       "dev": true,
-      "dependencies": {
-        "regenerator-runtime": "^0.13.11"
-      },
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.15.tgz",
-      "integrity": "sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.22.13",
-        "@babel/parser": "^7.22.15",
-        "@babel/types": "^7.22.15"
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1732,14 +1736,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.0.tgz",
-      "integrity": "sha512-0oIyUfKoI3mSqMvsxBdclDwxXKXAUA8v/apZbc+iSyARYou1o8ZGDxbUYyLFoW2arqS2jDGqJuZvv1d/io1axg==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.22.5",
-        "@babel/helper-validator-identifier": "^7.22.20",
-        "to-fast-properties": "^2.0.0"
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -3565,12 +3569,16 @@
       "dev": true
     },
     "node_modules/@sindresorhus/is": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
-      "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-5.6.0.tgz",
+      "integrity": "sha512-TV7t8GKYaJWsn00tFDqBw8+Uqmr8A0fRU1tvTQhyZzGv0sJCGRQL3JGMI3ucuKo3XIZdUP+Lx7/gh2t3lewy7g==",
       "dev": true,
+      "license": "MIT",
       "engines": {
-        "node": ">=6"
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
       }
     },
     "node_modules/@sindresorhus/merge-streams": {
@@ -3604,15 +3612,16 @@
       }
     },
     "node_modules/@szmarczak/http-timer": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
-      "integrity": "sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-5.0.1.tgz",
+      "integrity": "sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "defer-to-connect": "^1.0.1"
+        "defer-to-connect": "^2.0.1"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=14.16"
       }
     },
     "node_modules/@types/babel__core": {
@@ -3656,12 +3665,6 @@
         "@babel/types": "^7.3.0"
       }
     },
-    "node_modules/@types/estree": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.0.tgz",
-      "integrity": "sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==",
-      "dev": true
-    },
     "node_modules/@types/glob": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
@@ -3680,6 +3683,13 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/http-cache-semantics": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.4",
@@ -3765,18 +3775,6 @@
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.0.tgz",
       "integrity": "sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==",
       "dev": true
-    },
-    "node_modules/acorn": {
-      "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
-      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
-      "dev": true,
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
     },
     "node_modules/agent-base": {
       "version": "7.1.4",
@@ -4253,10 +4251,11 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -4347,31 +4346,46 @@
       "integrity": "sha512-uYBjakWipfaO/bXI7E8rq6kpwHRZK5cNYrUv2OzZSI/FvmdMyXJ2tG9dKcjEC5YHmHpUAwsargWIZNWdxb/bnQ==",
       "dev": true
     },
-    "node_modules/cacheable-request": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.1.0.tgz",
-      "integrity": "sha512-Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg==",
+    "node_modules/cacheable-lookup": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-7.0.0.tgz",
+      "integrity": "sha512-+qJyx4xiKra8mZrcwhjMRMUhD5NR1R8esPkzIYxX96JiecFoxAXFuz/GpR3+ev4PE1WamHip78wV0vcmPQtp8w==",
       "dev": true,
-      "dependencies": {
-        "clone-response": "^1.0.2",
-        "get-stream": "^5.1.0",
-        "http-cache-semantics": "^4.0.0",
-        "keyv": "^3.0.0",
-        "lowercase-keys": "^2.0.0",
-        "normalize-url": "^4.1.0",
-        "responselike": "^1.0.2"
-      },
+      "license": "MIT",
       "engines": {
-        "node": ">=8"
+        "node": ">=14.16"
       }
     },
-    "node_modules/cacheable-request/node_modules/lowercase-keys": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
-      "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+    "node_modules/cacheable-request": {
+      "version": "10.2.14",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-10.2.14.tgz",
+      "integrity": "sha512-zkDT5WAF4hSSoUgyfg5tFIxz8XQK+25W/TLVojJTMKBaxevLBBtLxgqguAuVQB8PVW79FVjHcU+GJ9tVbDZ9mQ==",
       "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-cache-semantics": "^4.0.2",
+        "get-stream": "^6.0.1",
+        "http-cache-semantics": "^4.1.1",
+        "keyv": "^4.5.3",
+        "mimic-response": "^4.0.0",
+        "normalize-url": "^8.0.0",
+        "responselike": "^3.0.0"
+      },
       "engines": {
-        "node": ">=8"
+        "node": ">=14.16"
+      }
+    },
+    "node_modules/cacheable-request/node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/caller-callsite": {
@@ -4714,15 +4728,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/cli-highlight/node_modules/yargs-parser": {
-      "version": "20.2.9",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/cli-table3": {
       "version": "0.6.5",
       "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.5.tgz",
@@ -4890,18 +4895,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/clone-response": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
-      "integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
-      "dev": true,
-      "dependencies": {
-        "mimic-response": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/co": {
@@ -5335,15 +5328,32 @@
       }
     },
     "node_modules/decompress-response": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
-      "integrity": "sha512-BzRPQuY1ip+qDonAOz42gRm/pg9F768C+npV/4JOsxRC2sq+Rlk+Q4ZCAsOhnIaMrgarILY+RMUIvMmmX1qAEA==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "mimic-response": "^1.0.0"
+        "mimic-response": "^3.1.0"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/decompress-response/node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/dedent": {
@@ -5371,10 +5381,14 @@
       }
     },
     "node_modules/defer-to-connect": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.3.tgz",
-      "integrity": "sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ==",
-      "dev": true
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+      "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/del": {
       "version": "4.1.1",
@@ -5459,12 +5473,6 @@
       "dependencies": {
         "readable-stream": "^2.0.2"
       }
-    },
-    "node_modules/duplexer3": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.5.tgz",
-      "integrity": "sha512-1A8za6ws41LQgv9HrE/66jyC5yuSjQ3L/KOpFtoBilsAK2iA2wuS5rTt1OCzIvtS2V7nVmedsUU+DGRcjBmOYA==",
-      "dev": true
     },
     "node_modules/electron-to-chromium": {
       "version": "1.4.284",
@@ -5901,6 +5909,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/form-data-encoder": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-2.1.4.tgz",
+      "integrity": "sha512-yDYSgNMraqvnxiEXO4hi88+YZxaHC6QKzb5N84iRCTDeRO7ZALpir/lVmf/uXUhnwUr2O4HU8s/n6x+yNjQkHw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.17"
+      }
+    },
     "node_modules/from2": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
@@ -6126,37 +6144,42 @@
       }
     },
     "node_modules/got": {
-      "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
-      "integrity": "sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==",
+      "version": "12.6.1",
+      "resolved": "https://registry.npmjs.org/got/-/got-12.6.1.tgz",
+      "integrity": "sha512-mThBblvlAF1d4O5oqyvN+ZxLAYwIJK7bpMxgYqPD9okW0C3qm5FFn7k811QrcuEBwaogR3ngOFoCfs6mRv7teQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@sindresorhus/is": "^0.14.0",
-        "@szmarczak/http-timer": "^1.1.2",
-        "cacheable-request": "^6.0.0",
-        "decompress-response": "^3.3.0",
-        "duplexer3": "^0.1.4",
-        "get-stream": "^4.1.0",
-        "lowercase-keys": "^1.0.1",
-        "mimic-response": "^1.0.1",
-        "p-cancelable": "^1.0.0",
-        "to-readable-stream": "^1.0.0",
-        "url-parse-lax": "^3.0.0"
+        "@sindresorhus/is": "^5.2.0",
+        "@szmarczak/http-timer": "^5.0.1",
+        "cacheable-lookup": "^7.0.0",
+        "cacheable-request": "^10.2.8",
+        "decompress-response": "^6.0.0",
+        "form-data-encoder": "^2.1.2",
+        "get-stream": "^6.0.1",
+        "http2-wrapper": "^2.1.10",
+        "lowercase-keys": "^3.0.0",
+        "p-cancelable": "^3.0.0",
+        "responselike": "^3.0.0"
       },
       "engines": {
-        "node": ">=8.6"
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/got?sponsor=1"
       }
     },
     "node_modules/got/node_modules/get-stream": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-      "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
       "dev": true,
-      "dependencies": {
-        "pump": "^3.0.0"
-      },
+      "license": "MIT",
       "engines": {
-        "node": ">=6"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/graceful-fs": {
@@ -6295,10 +6318,11 @@
       "dev": true
     },
     "node_modules/http-cache-semantics": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
-      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
-      "dev": true
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
     },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
@@ -6311,6 +6335,33 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/http2-wrapper": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-2.2.1.tgz",
+      "integrity": "sha512-V5nVw1PAOgfI3Lmeaj2Exmeg7fenjhRUgz1lPSezy1CuhPYbgQtbQj4jZfEAEMlaL+vupsvhjqCyjzob0yxsmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "quick-lru": "^5.1.1",
+        "resolve-alpn": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=10.19.0"
+      }
+    },
+    "node_modules/http2-wrapper/node_modules/quick-lru": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/https-proxy-agent": {
@@ -8489,26 +8540,12 @@
         "node": ">=8"
       }
     },
-    "node_modules/jest-snapshot/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/jest-snapshot/node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -8527,12 +8564,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/jest-snapshot/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
     },
     "node_modules/jest-util": {
       "version": "29.3.1",
@@ -8895,10 +8926,11 @@
       }
     },
     "node_modules/json-buffer": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
-      "integrity": "sha512-CuUqjv0FUZIdXkHPI8MezCnFCdaTAacej1TZYulLoAg1h/PhwkdXFN4V/gzY4g+fMBCOV2xF+rp7t2XD2ns/NQ==",
-      "dev": true
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/json-parse-better-errors": {
       "version": "1.0.2",
@@ -8943,12 +8975,13 @@
       }
     },
     "node_modules/keyv": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.1.0.tgz",
-      "integrity": "sha512-9ykJ/46SN/9KPM/sichzQ7OvXyGDYKGTaDlKMGCAlg2UK8KRy4jb0d8sFc+0Tt0YYnThq8X2RZgCg74RPxgcVA==",
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "json-buffer": "3.0.0"
+        "json-buffer": "3.0.1"
       }
     },
     "node_modules/kleur": {
@@ -9440,12 +9473,16 @@
       }
     },
     "node_modules/lowercase-keys": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-      "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-3.0.0.tgz",
+      "integrity": "sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
-        "node": ">=0.10.0"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/lru-cache": {
@@ -9692,15 +9729,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/meow/node_modules/camelcase": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-      "integrity": "sha512-FxAv7HpHrXbh3aPo4o2qxHay2lkLY3x5Mw3KeE4KQE8ysVfziWeRZDwcjauvwBSGEC/nXUPzZy8zeh4HokqOnw==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/meow/node_modules/find-up": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
@@ -9820,15 +9848,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/meow/node_modules/yargs-parser": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
-      "integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
-      "dev": true,
-      "dependencies": {
-        "camelcase": "^4.1.0"
-      }
-    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -9836,12 +9855,13 @@
       "dev": true
     },
     "node_modules/micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       },
       "engines": {
@@ -9873,19 +9893,24 @@
       }
     },
     "node_modules/mimic-response": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
-      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-4.0.0.tgz",
+      "integrity": "sha512-e5ISH9xMYU0DzrT+jl8q2ze9D6eWBto+I8CNpe+VI+K2J/F/k3PdkdTdz4wvGVH4NTpo+NRYTVIuMQEMMcsLqg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
-        "node": ">=4"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -10052,10 +10077,11 @@
       "dev": true
     },
     "node_modules/normalize-package-data/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "dev": true,
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver"
       }
@@ -10070,12 +10096,16 @@
       }
     },
     "node_modules/normalize-url": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.1.tgz",
-      "integrity": "sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA==",
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-8.1.1.tgz",
+      "integrity": "sha512-JYc0DPlpGWB40kH5g07gGTrYuMqV653k3uBKY6uITPWds3M0ov3GaWGp9lbE3Bzngx8+XkfzgvASb9vk9JDFXQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
-        "node": ">=8"
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/np": {
@@ -10247,9 +10277,9 @@
       }
     },
     "node_modules/npm": {
-      "version": "11.11.1",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-11.11.1.tgz",
-      "integrity": "sha512-asazCodkFdz1ReQzukyzS/DD77uGCIqUFeRG3gtaT8b9UR0ne1m9QOBuMgT72ij1rt7TRrOox4A1WzntMWIuEg==",
+      "version": "11.13.0",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-11.13.0.tgz",
+      "integrity": "sha512-cRmhaghDWA1lFgl3Ug4/VxDJdPBK/U+tNtnrl9kXunFqhWw1x4xL5txkNn7qzPuVfvXOmXyjHpMwsuk2uisbkg==",
       "bundleDependencies": [
         "@isaacs/string-locale-compare",
         "@npmcli/arborist",
@@ -10318,10 +10348,18 @@
         "which"
       ],
       "dev": true,
+      "license": "Artistic-2.0",
+      "workspaces": [
+        "docs",
+        "smoke-tests",
+        "mock-globals",
+        "mock-registry",
+        "workspaces/*"
+      ],
       "dependencies": {
         "@isaacs/string-locale-compare": "^1.1.0",
-        "@npmcli/arborist": "^9.4.1",
-        "@npmcli/config": "^10.7.1",
+        "@npmcli/arborist": "^9.4.3",
+        "@npmcli/config": "^10.8.1",
         "@npmcli/fs": "^5.0.0",
         "@npmcli/map-workspaces": "^5.0.3",
         "@npmcli/metavuln-calculator": "^9.0.3",
@@ -10329,10 +10367,10 @@
         "@npmcli/promise-spawn": "^9.0.1",
         "@npmcli/redact": "^4.0.0",
         "@npmcli/run-script": "^10.0.4",
-        "@sigstore/tuf": "^4.0.1",
+        "@sigstore/tuf": "^4.0.2",
         "abbrev": "^4.0.0",
         "archy": "~1.0.0",
-        "cacache": "^20.0.3",
+        "cacache": "^20.0.4",
         "chalk": "^5.6.2",
         "ci-info": "^4.4.0",
         "fastest-levenshtein": "^1.0.16",
@@ -10342,24 +10380,24 @@
         "hosted-git-info": "^9.0.2",
         "ini": "^6.0.0",
         "init-package-json": "^8.2.5",
-        "is-cidr": "^6.0.3",
+        "is-cidr": "^6.0.4",
         "json-parse-even-better-errors": "^5.0.0",
         "libnpmaccess": "^10.0.3",
-        "libnpmdiff": "^8.1.4",
-        "libnpmexec": "^10.2.4",
-        "libnpmfund": "^7.0.18",
+        "libnpmdiff": "^8.1.6",
+        "libnpmexec": "^10.2.6",
+        "libnpmfund": "^7.0.20",
         "libnpmorg": "^8.0.1",
-        "libnpmpack": "^9.1.4",
+        "libnpmpack": "^9.1.6",
         "libnpmpublish": "^11.1.3",
         "libnpmsearch": "^9.0.1",
         "libnpmteam": "^8.0.2",
         "libnpmversion": "^8.0.3",
-        "make-fetch-happen": "^15.0.4",
-        "minimatch": "^10.2.4",
+        "make-fetch-happen": "^15.0.5",
+        "minimatch": "^10.2.5",
         "minipass": "^7.1.3",
         "minipass-pipeline": "^1.2.4",
         "ms": "^2.1.2",
-        "node-gyp": "^12.2.0",
+        "node-gyp": "^12.3.0",
         "nopt": "^9.0.0",
         "npm-audit-report": "^7.0.0",
         "npm-install-checks": "^8.0.0",
@@ -10378,7 +10416,7 @@
         "spdx-expression-parse": "^4.0.0",
         "ssri": "^13.0.1",
         "supports-color": "^10.2.2",
-        "tar": "^7.5.11",
+        "tar": "^7.5.13",
         "text-table": "~0.2.0",
         "tiny-relative-date": "^2.0.2",
         "treeverse": "^3.0.0",
@@ -10424,24 +10462,12 @@
       }
     },
     "node_modules/npm/node_modules/@gar/promise-retry": {
-      "version": "1.0.2",
+      "version": "1.0.3",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "dependencies": {
-        "retry": "^0.13.1"
-      },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/npm/node_modules/@gar/promise-retry/node_modules/retry": {
-      "version": "0.13.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
       }
     },
     "node_modules/npm/node_modules/@isaacs/fs-minipass": {
@@ -10479,7 +10505,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/arborist": {
-      "version": "9.4.1",
+      "version": "9.4.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10527,7 +10553,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/config": {
-      "version": "10.7.1",
+      "version": "10.8.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10721,7 +10747,7 @@
       }
     },
     "node_modules/npm/node_modules/@sigstore/core": {
-      "version": "3.1.0",
+      "version": "3.2.0",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -10730,7 +10756,7 @@
       }
     },
     "node_modules/npm/node_modules/@sigstore/protobuf-specs": {
-      "version": "0.5.0",
+      "version": "0.5.1",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -10739,24 +10765,24 @@
       }
     },
     "node_modules/npm/node_modules/@sigstore/sign": {
-      "version": "4.1.0",
+      "version": "4.1.1",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
+        "@gar/promise-retry": "^1.0.2",
         "@sigstore/bundle": "^4.0.0",
-        "@sigstore/core": "^3.1.0",
+        "@sigstore/core": "^3.2.0",
         "@sigstore/protobuf-specs": "^0.5.0",
-        "make-fetch-happen": "^15.0.3",
-        "proc-log": "^6.1.0",
-        "promise-retry": "^2.0.1"
+        "make-fetch-happen": "^15.0.4",
+        "proc-log": "^6.1.0"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/@sigstore/tuf": {
-      "version": "4.0.1",
+      "version": "4.0.2",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -10872,7 +10898,7 @@
       }
     },
     "node_modules/npm/node_modules/brace-expansion": {
-      "version": "5.0.4",
+      "version": "5.0.5",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10884,7 +10910,7 @@
       }
     },
     "node_modules/npm/node_modules/cacache": {
-      "version": "20.0.3",
+      "version": "20.0.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10898,8 +10924,7 @@
         "minipass-flush": "^1.0.5",
         "minipass-pipeline": "^1.2.4",
         "p-map": "^7.0.2",
-        "ssri": "^13.0.0",
-        "unique-filename": "^5.0.0"
+        "ssri": "^13.0.0"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -10942,7 +10967,7 @@
       }
     },
     "node_modules/npm/node_modules/cidr-regex": {
-      "version": "5.0.3",
+      "version": "5.0.4",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
@@ -10998,7 +11023,7 @@
       }
     },
     "node_modules/npm/node_modules/diff": {
-      "version": "8.0.3",
+      "version": "8.0.4",
       "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
@@ -11018,7 +11043,6 @@
     "node_modules/npm/node_modules/err-code": {
       "version": "2.0.3",
       "dev": true,
-      "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/exponential-backoff": {
@@ -11147,7 +11171,6 @@
     "node_modules/npm/node_modules/imurmurhash": {
       "version": "0.1.4",
       "dev": true,
-      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
@@ -11189,12 +11212,12 @@
       }
     },
     "node_modules/npm/node_modules/is-cidr": {
-      "version": "6.0.3",
+      "version": "6.0.4",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "cidr-regex": "^5.0.1"
+        "cidr-regex": "^5.0.4"
       },
       "engines": {
         "node": ">=20"
@@ -11262,12 +11285,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmdiff": {
-      "version": "8.1.4",
+      "version": "8.1.6",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.4.1",
+        "@npmcli/arborist": "^9.4.3",
         "@npmcli/installed-package-contents": "^4.0.0",
         "binary-extensions": "^3.0.0",
         "diff": "^8.0.2",
@@ -11281,13 +11304,13 @@
       }
     },
     "node_modules/npm/node_modules/libnpmexec": {
-      "version": "10.2.4",
+      "version": "10.2.6",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "@gar/promise-retry": "^1.0.0",
-        "@npmcli/arborist": "^9.4.1",
+        "@npmcli/arborist": "^9.4.3",
         "@npmcli/package-json": "^7.0.0",
         "@npmcli/run-script": "^10.0.0",
         "ci-info": "^4.0.0",
@@ -11304,12 +11327,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmfund": {
-      "version": "7.0.18",
+      "version": "7.0.20",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.4.1"
+        "@npmcli/arborist": "^9.4.3"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -11329,12 +11352,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmpack": {
-      "version": "9.1.4",
+      "version": "9.1.6",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.4.1",
+        "@npmcli/arborist": "^9.4.3",
         "@npmcli/run-script": "^10.0.0",
         "npm-package-arg": "^13.0.0",
         "pacote": "^21.0.2"
@@ -11404,7 +11427,7 @@
       }
     },
     "node_modules/npm/node_modules/lru-cache": {
-      "version": "11.2.6",
+      "version": "11.3.5",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
@@ -11413,13 +11436,14 @@
       }
     },
     "node_modules/npm/node_modules/make-fetch-happen": {
-      "version": "15.0.4",
+      "version": "15.0.5",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "@gar/promise-retry": "^1.0.0",
         "@npmcli/agent": "^4.0.0",
+        "@npmcli/redact": "^4.0.0",
         "cacache": "^20.0.1",
         "http-cache-semantics": "^4.1.1",
         "minipass": "^7.0.2",
@@ -11435,12 +11459,12 @@
       }
     },
     "node_modules/npm/node_modules/minimatch": {
-      "version": "10.2.4",
+      "version": "10.2.5",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.2"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -11488,34 +11512,16 @@
       }
     },
     "node_modules/npm/node_modules/minipass-flush": {
-      "version": "1.0.5",
+      "version": "1.0.6",
       "dev": true,
       "inBundle": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "minipass": "^3.0.0"
+        "minipass": "^7.1.3"
       },
       "engines": {
-        "node": ">= 8"
+        "node": ">=16 || 14 >=14.17"
       }
-    },
-    "node_modules/npm/node_modules/minipass-flush/node_modules/minipass": {
-      "version": "3.3.6",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/minipass-flush/node_modules/yallist": {
-      "version": "4.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
     },
     "node_modules/npm/node_modules/minipass-pipeline": {
       "version": "1.2.4",
@@ -11596,7 +11602,7 @@
       }
     },
     "node_modules/npm/node_modules/node-gyp": {
-      "version": "12.2.0",
+      "version": "12.3.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11604,12 +11610,12 @@
         "env-paths": "^2.2.0",
         "exponential-backoff": "^3.1.1",
         "graceful-fs": "^4.2.6",
-        "make-fetch-happen": "^15.0.0",
         "nopt": "^9.0.0",
         "proc-log": "^6.0.0",
         "semver": "^7.3.5",
         "tar": "^7.5.4",
         "tinyglobby": "^0.2.12",
+        "undici": "^6.25.0",
         "which": "^6.0.0"
       },
       "bin": {
@@ -11885,7 +11891,6 @@
     "node_modules/npm/node_modules/promise-retry": {
       "version": "2.0.1",
       "dev": true,
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "err-code": "^2.0.2",
@@ -11939,7 +11944,6 @@
     "node_modules/npm/node_modules/retry": {
       "version": "0.12.0",
       "dev": true,
-      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -12078,7 +12082,7 @@
       }
     },
     "node_modules/npm/node_modules/tar": {
-      "version": "7.5.11",
+      "version": "7.5.13",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
@@ -12106,13 +12110,13 @@
       "license": "MIT"
     },
     "node_modules/npm/node_modules/tinyglobby": {
-      "version": "0.2.15",
+      "version": "0.2.16",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -12139,7 +12143,7 @@
       }
     },
     "node_modules/npm/node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
+      "version": "4.0.4",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -12173,10 +12177,18 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
+    "node_modules/npm/node_modules/undici": {
+      "version": "6.25.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
     "node_modules/npm/node_modules/unique-filename": {
       "version": "5.0.0",
       "dev": true,
-      "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "unique-slug": "^6.0.0"
@@ -12188,7 +12200,6 @@
     "node_modules/npm/node_modules/unique-slug": {
       "version": "6.0.0",
       "dev": true,
-      "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "imurmurhash": "^0.1.4"
@@ -12328,15 +12339,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/ow": {
       "version": "0.15.1",
       "resolved": "https://registry.npmjs.org/ow/-/ow-0.15.1.tgz",
@@ -12362,12 +12364,13 @@
       }
     },
     "node_modules/p-cancelable": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
-      "integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-3.0.0.tgz",
+      "integrity": "sha512-mlVgR3PGuzlo0MmTdk4cXqXWlwQDLnONTAg6sm62XkMJEiRxN3GL3SffkYvqwonbkJBcrI7Uvv5Zh9yjvn2iUw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
-        "node": ">=6"
+        "node": ">=12.20"
       }
     },
     "node_modules/p-defer": {
@@ -12711,12 +12714,13 @@
       "dev": true
     },
     "node_modules/picomatch": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
-        "node": ">=8.6"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
@@ -12842,15 +12846,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/prepend-http": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
-      "integrity": "sha512-ravE6m9Atw9Z/jjttRUZ+clIXogdghyZAuWJ3qEzjT+jI/dL1ifAqhZeC5VHzQp1MSt1+jxKkFNemj/iO7tVUA==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/prettier": {
@@ -13224,12 +13219,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/regenerator-runtime": {
-      "version": "0.13.11",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
-      "dev": true
-    },
     "node_modules/regenerator-transform": {
       "version": "0.15.1",
       "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.15.1.tgz",
@@ -13333,6 +13322,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/resolve-alpn": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
+      "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/resolve-cwd": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
@@ -13364,12 +13360,19 @@
       }
     },
     "node_modules/responselike": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
-      "integrity": "sha512-/Fpe5guzJk1gPqdJLJR5u7eG/gNY4nImjbRDaVWVMRhne55TCmj2i9Q+54PBRfatRC8v/rIiv9BN0pMd9OV5EQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-3.0.0.tgz",
+      "integrity": "sha512-40yHxbNcl2+rzXvZuVkrYohathsSJlMTXKryG5y8uciHv1+xDLHQpgjG64JUO9nrEq2jGLH6IZ8BcZyw3wrweg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "lowercase-keys": "^1.0.0"
+        "lowercase-keys": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/restore-cursor": {
@@ -13398,17 +13401,19 @@
       }
     },
     "node_modules/rollup": {
-      "version": "1.32.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.32.1.tgz",
-      "integrity": "sha512-/2HA0Ec70TvQnXdzynFffkjA6XN+1e2pEv/uKS5Ulca40g2L7KuOE3riasHoNVHOsFD5KKZgDsMk1CP3Tw9s+A==",
+      "version": "2.80.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.80.0.tgz",
+      "integrity": "sha512-cIFJOD1DESzpjOBl763Kp1AH7UE/0fcdHe6rZXUdQ9c50uvgigvW97u3IcSeBwOkgqL/PXPBktBCh0KEu5L8XQ==",
       "dev": true,
-      "dependencies": {
-        "@types/estree": "*",
-        "@types/node": "*",
-        "acorn": "^7.1.0"
-      },
+      "license": "MIT",
       "bin": {
         "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
       }
     },
     "node_modules/rollup-plugin-babel": {
@@ -13861,21 +13866,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/semantic-release/node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
     "node_modules/semantic-release/node_modules/wrap-ansi": {
       "version": "9.0.2",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
@@ -13910,20 +13900,12 @@
         "node": "^20.19.0 || ^22.12.0 || >=23"
       }
     },
-    "node_modules/semantic-release/node_modules/yargs-parser": {
-      "version": "22.0.0",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
-      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
-      "dev": true,
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=23"
-      }
-    },
     "node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -14686,18 +14668,6 @@
         }
       }
     },
-    "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/tlds": {
       "version": "1.236.0",
       "resolved": "https://registry.npmjs.org/tlds/-/tlds-1.236.0.tgz",
@@ -14708,15 +14678,13 @@
       }
     },
     "node_modules/tmp": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
       "dev": true,
-      "dependencies": {
-        "os-tmpdir": "~1.0.2"
-      },
+      "license": "MIT",
       "engines": {
-        "node": ">=0.6.0"
+        "node": ">=14.14"
       }
     },
     "node_modules/tmpl": {
@@ -14724,24 +14692,6 @@
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
       "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
       "dev": true
-    },
-    "node_modules/to-fast-properties": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/to-readable-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
-      "integrity": "sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
@@ -14822,38 +14772,18 @@
         }
       }
     },
-    "node_modules/ts-jest/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/ts-jest/node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/ts-jest/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
     },
     "node_modules/ts-jest/node_modules/yargs-parser": {
       "version": "21.1.1",
@@ -15116,10 +15046,11 @@
       }
     },
     "node_modules/update-notifier/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "dev": true,
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver"
       }
@@ -15143,18 +15074,6 @@
       "dev": true,
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      }
-    },
-    "node_modules/url-parse-lax": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
-      "integrity": "sha512-NjFKA0DidqPa5ciFcSrXnAltTtzz84ogy+NebPvfEgAck0+TNg4UJ4IN+fB7zRZfbgUf0syOo9MDxFkDSMuFaQ==",
-      "dev": true,
-      "dependencies": {
-        "prepend-http": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/url-regex": {
@@ -15326,10 +15245,11 @@
       }
     },
     "node_modules/windows-release/node_modules/cross-spawn": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.6.tgz",
+      "integrity": "sha512-VqCUuhcd1iB+dsv8gxPttb5iZh/D0iubSP21g36KXdEuf6I5JiioesUVjpCdHV9MZRUfVFlvwtIUyPfxo5trtw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "nice-try": "^1.0.4",
         "path-key": "^2.0.1",
@@ -15411,10 +15331,11 @@
       }
     },
     "node_modules/windows-release/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "dev": true,
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver"
       }
@@ -15956,9 +15877,9 @@
       }
     },
     "@babel/helper-string-parser": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz",
-      "integrity": "sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
       "dev": true
     },
     "@babel/helper-validator-identifier": {
@@ -15986,21 +15907,23 @@
       }
     },
     "@babel/helpers": {
-      "version": "7.20.7",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.20.7.tgz",
-      "integrity": "sha512-PBPjs5BppzsGaxHQCDKnZ6Gd9s6xl8bBCluz3vEInLGRJmnZan4F6BYCeqtyXqkk4W5IlPmjK4JlOuZkpJ3xZA==",
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
       "dev": true,
       "requires": {
-        "@babel/template": "^7.20.7",
-        "@babel/traverse": "^7.20.7",
-        "@babel/types": "^7.20.7"
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0"
       }
     },
     "@babel/parser": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.0.tgz",
-      "integrity": "sha512-vvPKKdMemU85V9WE/l5wZEmImpCtLqbnTvqDS2U1fJ96KrxoW7KrXhNsNCblQlg8Ck4b85yxdTyelsMUgFUXiw==",
-      "dev": true
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.29.0"
+      }
     },
     "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
       "version": "7.18.6",
@@ -16786,23 +16709,20 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.20.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.7.tgz",
-      "integrity": "sha512-UF0tvkUtxwAgZ5W/KrkHf0Rn0fdnLDU9ScxBrEVNUprE/MzirjK4MJUX1/BVDv00Sv8cljtukVK1aky++X1SjQ==",
-      "dev": true,
-      "requires": {
-        "regenerator-runtime": "^0.13.11"
-      }
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "dev": true
     },
     "@babel/template": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.15.tgz",
-      "integrity": "sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.22.13",
-        "@babel/parser": "^7.22.15",
-        "@babel/types": "^7.22.15"
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
       }
     },
     "@babel/traverse": {
@@ -16824,14 +16744,13 @@
       }
     },
     "@babel/types": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.0.tgz",
-      "integrity": "sha512-0oIyUfKoI3mSqMvsxBdclDwxXKXAUA8v/apZbc+iSyARYou1o8ZGDxbUYyLFoW2arqS2jDGqJuZvv1d/io1axg==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
       "dev": true,
       "requires": {
-        "@babel/helper-string-parser": "^7.22.5",
-        "@babel/helper-validator-identifier": "^7.22.20",
-        "to-fast-properties": "^2.0.0"
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
       }
     },
     "@bcoe/v8-coverage": {
@@ -17604,7 +17523,7 @@
         "detect-indent": "^6.0.0",
         "execa": "^2.0.3",
         "resolve-from": "^5.0.0",
-        "yargs-parser": "^13.1.1"
+        "yargs-parser": "^13.1.2"
       }
     },
     "@pika/pack": {
@@ -17630,7 +17549,7 @@
         "strip-ansi": "^5.2.0",
         "strip-bom": "^4.0.0",
         "validate-npm-package-license": "^3.0.4",
-        "yargs-parser": "^13.1.1"
+        "yargs-parser": "^13.1.2"
       }
     },
     "@pika/plugin-build-node": {
@@ -17646,7 +17565,7 @@
         "@pika/types": "^0.9.2",
         "babel-plugin-dynamic-import-node-babel-7": "^2.0.7",
         "builtin-modules": "^3.0.0",
-        "rollup": "^1.1.0",
+        "rollup": "^2.80.0",
         "rollup-plugin-babel": "^4.3.0"
       },
       "dependencies": {
@@ -17918,7 +17837,7 @@
         "lodash-es": "^4.17.21",
         "nerf-dart": "^1.0.0",
         "normalize-url": "^9.0.0",
-        "npm": "^11.6.2",
+        "npm": "^11.13.0",
         "rc": "^1.2.8",
         "read-pkg": "^10.0.0",
         "registry-auth-token": "^5.0.0",
@@ -18227,9 +18146,9 @@
       "dev": true
     },
     "@sindresorhus/is": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
-      "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-5.6.0.tgz",
+      "integrity": "sha512-TV7t8GKYaJWsn00tFDqBw8+Uqmr8A0fRU1tvTQhyZzGv0sJCGRQL3JGMI3ucuKo3XIZdUP+Lx7/gh2t3lewy7g==",
       "dev": true
     },
     "@sindresorhus/merge-streams": {
@@ -18257,12 +18176,12 @@
       }
     },
     "@szmarczak/http-timer": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
-      "integrity": "sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-5.0.1.tgz",
+      "integrity": "sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==",
       "dev": true,
       "requires": {
-        "defer-to-connect": "^1.0.1"
+        "defer-to-connect": "^2.0.1"
       }
     },
     "@types/babel__core": {
@@ -18306,12 +18225,6 @@
         "@babel/types": "^7.3.0"
       }
     },
-    "@types/estree": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.0.tgz",
-      "integrity": "sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==",
-      "dev": true
-    },
     "@types/glob": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
@@ -18330,6 +18243,12 @@
       "requires": {
         "@types/node": "*"
       }
+    },
+    "@types/http-cache-semantics": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==",
+      "dev": true
     },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.4",
@@ -18416,12 +18335,6 @@
       "integrity": "sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==",
       "dev": true
     },
-    "acorn": {
-      "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
-      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
-      "dev": true
-    },
     "agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -18498,7 +18411,7 @@
       "dev": true,
       "requires": {
         "normalize-path": "^3.0.0",
-        "picomatch": "^2.0.4"
+        "picomatch": "^4.0.4"
       }
     },
     "argparse": {
@@ -18781,9 +18694,9 @@
       }
     },
     "brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
@@ -18847,25 +18760,31 @@
       "integrity": "sha512-uYBjakWipfaO/bXI7E8rq6kpwHRZK5cNYrUv2OzZSI/FvmdMyXJ2tG9dKcjEC5YHmHpUAwsargWIZNWdxb/bnQ==",
       "dev": true
     },
+    "cacheable-lookup": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-7.0.0.tgz",
+      "integrity": "sha512-+qJyx4xiKra8mZrcwhjMRMUhD5NR1R8esPkzIYxX96JiecFoxAXFuz/GpR3+ev4PE1WamHip78wV0vcmPQtp8w==",
+      "dev": true
+    },
     "cacheable-request": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.1.0.tgz",
-      "integrity": "sha512-Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg==",
+      "version": "10.2.14",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-10.2.14.tgz",
+      "integrity": "sha512-zkDT5WAF4hSSoUgyfg5tFIxz8XQK+25W/TLVojJTMKBaxevLBBtLxgqguAuVQB8PVW79FVjHcU+GJ9tVbDZ9mQ==",
       "dev": true,
       "requires": {
-        "clone-response": "^1.0.2",
-        "get-stream": "^5.1.0",
-        "http-cache-semantics": "^4.0.0",
-        "keyv": "^3.0.0",
-        "lowercase-keys": "^2.0.0",
-        "normalize-url": "^4.1.0",
-        "responselike": "^1.0.2"
+        "@types/http-cache-semantics": "^4.0.2",
+        "get-stream": "^6.0.1",
+        "http-cache-semantics": "^4.1.1",
+        "keyv": "^4.5.3",
+        "mimic-response": "^4.0.0",
+        "normalize-url": "^8.0.0",
+        "responselike": "^3.0.0"
       },
       "dependencies": {
-        "lowercase-keys": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
-          "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+        "get-stream": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+          "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
           "dev": true
         }
       }
@@ -19112,14 +19031,8 @@
             "require-directory": "^2.1.1",
             "string-width": "^4.2.0",
             "y18n": "^5.0.5",
-            "yargs-parser": "^20.2.2"
+            "yargs-parser": "^13.1.2"
           }
-        },
-        "yargs-parser": {
-          "version": "20.2.9",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-          "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
-          "dev": true
         }
       }
     },
@@ -19247,15 +19160,6 @@
             "strip-ansi": "^6.0.0"
           }
         }
-      }
-    },
-    "clone-response": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
-      "integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
-      "dev": true,
-      "requires": {
-        "mimic-response": "^1.0.0"
       }
     },
     "co": {
@@ -19583,12 +19487,20 @@
       }
     },
     "decompress-response": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
-      "integrity": "sha512-BzRPQuY1ip+qDonAOz42gRm/pg9F768C+npV/4JOsxRC2sq+Rlk+Q4ZCAsOhnIaMrgarILY+RMUIvMmmX1qAEA==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
       "dev": true,
       "requires": {
-        "mimic-response": "^1.0.0"
+        "mimic-response": "^3.1.0"
+      },
+      "dependencies": {
+        "mimic-response": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+          "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+          "dev": true
+        }
       }
     },
     "dedent": {
@@ -19610,9 +19522,9 @@
       "dev": true
     },
     "defer-to-connect": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.3.tgz",
-      "integrity": "sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+      "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
       "dev": true
     },
     "del": {
@@ -19680,12 +19592,6 @@
       "requires": {
         "readable-stream": "^2.0.2"
       }
-    },
-    "duplexer3": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.5.tgz",
-      "integrity": "sha512-1A8za6ws41LQgv9HrE/66jyC5yuSjQ3L/KOpFtoBilsAK2iA2wuS5rTt1OCzIvtS2V7nVmedsUU+DGRcjBmOYA==",
-      "dev": true
     },
     "electron-to-chromium": {
       "version": "1.4.284",
@@ -19910,7 +19816,7 @@
       "requires": {
         "chardet": "^0.7.0",
         "iconv-lite": "^0.4.24",
-        "tmp": "^0.0.33"
+        "tmp": "^0.2.4"
       }
     },
     "fast-content-type-parse": {
@@ -19983,6 +19889,12 @@
         "semver-regex": "^4.0.5",
         "super-regex": "^1.0.0"
       }
+    },
+    "form-data-encoder": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-2.1.4.tgz",
+      "integrity": "sha512-yDYSgNMraqvnxiEXO4hi88+YZxaHC6QKzb5N84iRCTDeRO7ZALpir/lVmf/uXUhnwUr2O4HU8s/n6x+yNjQkHw==",
+      "dev": true
     },
     "from2": {
       "version": "2.3.0",
@@ -20155,32 +20067,29 @@
       }
     },
     "got": {
-      "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
-      "integrity": "sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==",
+      "version": "12.6.1",
+      "resolved": "https://registry.npmjs.org/got/-/got-12.6.1.tgz",
+      "integrity": "sha512-mThBblvlAF1d4O5oqyvN+ZxLAYwIJK7bpMxgYqPD9okW0C3qm5FFn7k811QrcuEBwaogR3ngOFoCfs6mRv7teQ==",
       "dev": true,
       "requires": {
-        "@sindresorhus/is": "^0.14.0",
-        "@szmarczak/http-timer": "^1.1.2",
-        "cacheable-request": "^6.0.0",
-        "decompress-response": "^3.3.0",
-        "duplexer3": "^0.1.4",
-        "get-stream": "^4.1.0",
-        "lowercase-keys": "^1.0.1",
-        "mimic-response": "^1.0.1",
-        "p-cancelable": "^1.0.0",
-        "to-readable-stream": "^1.0.0",
-        "url-parse-lax": "^3.0.0"
+        "@sindresorhus/is": "^5.2.0",
+        "@szmarczak/http-timer": "^5.0.1",
+        "cacheable-lookup": "^7.0.0",
+        "cacheable-request": "^10.2.8",
+        "decompress-response": "^6.0.0",
+        "form-data-encoder": "^2.1.2",
+        "get-stream": "^6.0.1",
+        "http2-wrapper": "^2.1.10",
+        "lowercase-keys": "^3.0.0",
+        "p-cancelable": "^3.0.0",
+        "responselike": "^3.0.0"
       },
       "dependencies": {
         "get-stream": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
-          "dev": true,
-          "requires": {
-            "pump": "^3.0.0"
-          }
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+          "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+          "dev": true
         }
       }
     },
@@ -20286,9 +20195,9 @@
       "dev": true
     },
     "http-cache-semantics": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
-      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
       "dev": true
     },
     "http-proxy-agent": {
@@ -20299,6 +20208,24 @@
       "requires": {
         "agent-base": "^7.1.0",
         "debug": "^4.3.4"
+      }
+    },
+    "http2-wrapper": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-2.2.1.tgz",
+      "integrity": "sha512-V5nVw1PAOgfI3Lmeaj2Exmeg7fenjhRUgz1lPSezy1CuhPYbgQtbQj4jZfEAEMlaL+vupsvhjqCyjzob0yxsmQ==",
+      "dev": true,
+      "requires": {
+        "quick-lru": "^5.1.1",
+        "resolve-alpn": "^1.2.0"
+      },
+      "dependencies": {
+        "quick-lru": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+          "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+          "dev": true
+        }
       }
     },
     "https-proxy-agent": {
@@ -21911,23 +21838,11 @@
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
-        "lru-cache": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-          "dev": true,
-          "requires": {
-            "yallist": "^4.0.0"
-          }
-        },
         "semver": {
-          "version": "7.3.8",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
+          "version": "7.7.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+          "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+          "dev": true
         },
         "supports-color": {
           "version": "7.2.0",
@@ -21937,12 +21852,6 @@
           "requires": {
             "has-flag": "^4.0.0"
           }
-        },
-        "yallist": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-          "dev": true
         }
       }
     },
@@ -21957,7 +21866,7 @@
         "chalk": "^4.0.0",
         "ci-info": "^3.2.0",
         "graceful-fs": "^4.2.9",
-        "picomatch": "^2.2.3"
+        "picomatch": "^4.0.4"
       },
       "dependencies": {
         "ansi-styles": {
@@ -22207,9 +22116,9 @@
       "dev": true
     },
     "json-buffer": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
-      "integrity": "sha512-CuUqjv0FUZIdXkHPI8MezCnFCdaTAacej1TZYulLoAg1h/PhwkdXFN4V/gzY4g+fMBCOV2xF+rp7t2XD2ns/NQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "dev": true
     },
     "json-parse-better-errors": {
@@ -22247,12 +22156,12 @@
       }
     },
     "keyv": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.1.0.tgz",
-      "integrity": "sha512-9ykJ/46SN/9KPM/sichzQ7OvXyGDYKGTaDlKMGCAlg2UK8KRy4jb0d8sFc+0Tt0YYnThq8X2RZgCg74RPxgcVA==",
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
       "dev": true,
       "requires": {
-        "json-buffer": "3.0.0"
+        "json-buffer": "3.0.1"
       }
     },
     "kleur": {
@@ -22646,9 +22555,9 @@
       }
     },
     "lowercase-keys": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-      "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-3.0.0.tgz",
+      "integrity": "sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==",
       "dev": true
     },
     "lru-cache": {
@@ -22818,15 +22727,9 @@
         "read-pkg-up": "^3.0.0",
         "redent": "^2.0.0",
         "trim-newlines": "^2.0.0",
-        "yargs-parser": "^10.0.0"
+        "yargs-parser": "^13.1.2"
       },
       "dependencies": {
-        "camelcase": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-          "integrity": "sha512-FxAv7HpHrXbh3aPo4o2qxHay2lkLY3x5Mw3KeE4KQE8ysVfziWeRZDwcjauvwBSGEC/nXUPzZy8zeh4HokqOnw==",
-          "dev": true
-        },
         "find-up": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
@@ -22915,15 +22818,6 @@
             "find-up": "^2.0.0",
             "read-pkg": "^3.0.0"
           }
-        },
-        "yargs-parser": {
-          "version": "10.1.0",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
-          "integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
-          "dev": true,
-          "requires": {
-            "camelcase": "^4.1.0"
-          }
         }
       }
     },
@@ -22934,13 +22828,13 @@
       "dev": true
     },
     "micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
       "requires": {
-        "braces": "^3.0.2",
-        "picomatch": "^2.3.1"
+        "braces": "^3.0.3",
+        "picomatch": "^4.0.4"
       }
     },
     "mime": {
@@ -22956,15 +22850,15 @@
       "dev": true
     },
     "mimic-response": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
-      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-4.0.0.tgz",
+      "integrity": "sha512-e5ISH9xMYU0DzrT+jl8q2ze9D6eWBto+I8CNpe+VI+K2J/F/k3PdkdTdz4wvGVH4NTpo+NRYTVIuMQEMMcsLqg==",
       "dev": true
     },
     "minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
@@ -23102,9 +22996,9 @@
           "dev": true
         },
         "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "version": "5.7.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+          "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
           "dev": true
         }
       }
@@ -23116,9 +23010,9 @@
       "dev": true
     },
     "normalize-url": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.1.tgz",
-      "integrity": "sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA==",
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-8.1.1.tgz",
+      "integrity": "sha512-JYc0DPlpGWB40kH5g07gGTrYuMqV653k3uBKY6uITPWds3M0ov3GaWGp9lbE3Bzngx8+XkfzgvASb9vk9JDFXQ==",
       "dev": true
     },
     "np": {
@@ -23253,14 +23147,14 @@
       }
     },
     "npm": {
-      "version": "11.11.1",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-11.11.1.tgz",
-      "integrity": "sha512-asazCodkFdz1ReQzukyzS/DD77uGCIqUFeRG3gtaT8b9UR0ne1m9QOBuMgT72ij1rt7TRrOox4A1WzntMWIuEg==",
+      "version": "11.13.0",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-11.13.0.tgz",
+      "integrity": "sha512-cRmhaghDWA1lFgl3Ug4/VxDJdPBK/U+tNtnrl9kXunFqhWw1x4xL5txkNn7qzPuVfvXOmXyjHpMwsuk2uisbkg==",
       "dev": true,
       "requires": {
         "@isaacs/string-locale-compare": "^1.1.0",
-        "@npmcli/arborist": "^9.4.1",
-        "@npmcli/config": "^10.7.1",
+        "@npmcli/arborist": "^9.4.3",
+        "@npmcli/config": "^10.8.1",
         "@npmcli/fs": "^5.0.0",
         "@npmcli/map-workspaces": "^5.0.3",
         "@npmcli/metavuln-calculator": "^9.0.3",
@@ -23268,10 +23162,10 @@
         "@npmcli/promise-spawn": "^9.0.1",
         "@npmcli/redact": "^4.0.0",
         "@npmcli/run-script": "^10.0.4",
-        "@sigstore/tuf": "^4.0.1",
+        "@sigstore/tuf": "^4.0.2",
         "abbrev": "^4.0.0",
         "archy": "~1.0.0",
-        "cacache": "^20.0.3",
+        "cacache": "^20.0.4",
         "chalk": "^5.6.2",
         "ci-info": "^4.4.0",
         "fastest-levenshtein": "^1.0.16",
@@ -23281,24 +23175,24 @@
         "hosted-git-info": "^9.0.2",
         "ini": "^6.0.0",
         "init-package-json": "^8.2.5",
-        "is-cidr": "^6.0.3",
+        "is-cidr": "^6.0.4",
         "json-parse-even-better-errors": "^5.0.0",
         "libnpmaccess": "^10.0.3",
-        "libnpmdiff": "^8.1.4",
-        "libnpmexec": "^10.2.4",
-        "libnpmfund": "^7.0.18",
+        "libnpmdiff": "^8.1.6",
+        "libnpmexec": "^10.2.6",
+        "libnpmfund": "^7.0.20",
         "libnpmorg": "^8.0.1",
-        "libnpmpack": "^9.1.4",
+        "libnpmpack": "^9.1.6",
         "libnpmpublish": "^11.1.3",
         "libnpmsearch": "^9.0.1",
         "libnpmteam": "^8.0.2",
         "libnpmversion": "^8.0.3",
-        "make-fetch-happen": "^15.0.4",
-        "minimatch": "^10.2.4",
+        "make-fetch-happen": "^15.0.5",
+        "minimatch": "^10.2.5",
         "minipass": "^7.1.3",
         "minipass-pipeline": "^1.2.4",
         "ms": "^2.1.2",
-        "node-gyp": "^12.2.0",
+        "node-gyp": "^12.3.0",
         "nopt": "^9.0.0",
         "npm-audit-report": "^7.0.0",
         "npm-install-checks": "^8.0.0",
@@ -23317,7 +23211,7 @@
         "spdx-expression-parse": "^4.0.0",
         "ssri": "^13.0.1",
         "supports-color": "^10.2.2",
-        "tar": "^7.5.11",
+        "tar": "^7.5.13",
         "text-table": "~0.2.0",
         "tiny-relative-date": "^2.0.2",
         "treeverse": "^3.0.0",
@@ -23326,19 +23220,9 @@
       },
       "dependencies": {
         "@gar/promise-retry": {
-          "version": "1.0.2",
+          "version": "1.0.3",
           "bundled": true,
-          "dev": true,
-          "requires": {
-            "retry": "^0.13.1"
-          },
-          "dependencies": {
-            "retry": {
-              "version": "0.13.1",
-              "bundled": true,
-              "dev": true
-            }
-          }
+          "dev": true
         },
         "@isaacs/fs-minipass": {
           "version": "4.0.1",
@@ -23366,7 +23250,7 @@
           }
         },
         "@npmcli/arborist": {
-          "version": "9.4.1",
+          "version": "9.4.3",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -23407,7 +23291,7 @@
           }
         },
         "@npmcli/config": {
-          "version": "10.7.1",
+          "version": "10.8.1",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -23542,30 +23426,30 @@
           }
         },
         "@sigstore/core": {
-          "version": "3.1.0",
+          "version": "3.2.0",
           "bundled": true,
           "dev": true
         },
         "@sigstore/protobuf-specs": {
-          "version": "0.5.0",
+          "version": "0.5.1",
           "bundled": true,
           "dev": true
         },
         "@sigstore/sign": {
-          "version": "4.1.0",
+          "version": "4.1.1",
           "bundled": true,
           "dev": true,
           "requires": {
+            "@gar/promise-retry": "^1.0.2",
             "@sigstore/bundle": "^4.0.0",
-            "@sigstore/core": "^3.1.0",
+            "@sigstore/core": "^3.2.0",
             "@sigstore/protobuf-specs": "^0.5.0",
-            "make-fetch-happen": "^15.0.3",
-            "proc-log": "^6.1.0",
-            "promise-retry": "^2.0.1"
+            "make-fetch-happen": "^15.0.4",
+            "proc-log": "^6.1.0"
           }
         },
         "@sigstore/tuf": {
-          "version": "4.0.1",
+          "version": "4.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -23640,7 +23524,7 @@
           "dev": true
         },
         "brace-expansion": {
-          "version": "5.0.4",
+          "version": "5.0.5",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -23648,7 +23532,7 @@
           }
         },
         "cacache": {
-          "version": "20.0.3",
+          "version": "20.0.4",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -23661,8 +23545,7 @@
             "minipass-flush": "^1.0.5",
             "minipass-pipeline": "^1.2.4",
             "p-map": "^7.0.2",
-            "ssri": "^13.0.0",
-            "unique-filename": "^5.0.0"
+            "ssri": "^13.0.0"
           }
         },
         "chalk": {
@@ -23681,7 +23564,7 @@
           "dev": true
         },
         "cidr-regex": {
-          "version": "5.0.3",
+          "version": "5.0.4",
           "bundled": true,
           "dev": true
         },
@@ -23709,7 +23592,7 @@
           }
         },
         "diff": {
-          "version": "8.0.3",
+          "version": "8.0.4",
           "bundled": true,
           "dev": true
         },
@@ -23720,7 +23603,6 @@
         },
         "err-code": {
           "version": "2.0.3",
-          "bundled": true,
           "dev": true
         },
         "exponential-backoff": {
@@ -23806,7 +23688,6 @@
         },
         "imurmurhash": {
           "version": "0.1.4",
-          "bundled": true,
           "dev": true
         },
         "ini": {
@@ -23833,11 +23714,11 @@
           "dev": true
         },
         "is-cidr": {
-          "version": "6.0.3",
+          "version": "6.0.4",
           "bundled": true,
           "dev": true,
           "requires": {
-            "cidr-regex": "^5.0.1"
+            "cidr-regex": "^5.0.4"
           }
         },
         "isexe": {
@@ -23880,11 +23761,11 @@
           }
         },
         "libnpmdiff": {
-          "version": "8.1.4",
+          "version": "8.1.6",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@npmcli/arborist": "^9.4.1",
+            "@npmcli/arborist": "^9.4.3",
             "@npmcli/installed-package-contents": "^4.0.0",
             "binary-extensions": "^3.0.0",
             "diff": "^8.0.2",
@@ -23895,12 +23776,12 @@
           }
         },
         "libnpmexec": {
-          "version": "10.2.4",
+          "version": "10.2.6",
           "bundled": true,
           "dev": true,
           "requires": {
             "@gar/promise-retry": "^1.0.0",
-            "@npmcli/arborist": "^9.4.1",
+            "@npmcli/arborist": "^9.4.3",
             "@npmcli/package-json": "^7.0.0",
             "@npmcli/run-script": "^10.0.0",
             "ci-info": "^4.0.0",
@@ -23914,11 +23795,11 @@
           }
         },
         "libnpmfund": {
-          "version": "7.0.18",
+          "version": "7.0.20",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@npmcli/arborist": "^9.4.1"
+            "@npmcli/arborist": "^9.4.3"
           }
         },
         "libnpmorg": {
@@ -23931,11 +23812,11 @@
           }
         },
         "libnpmpack": {
-          "version": "9.1.4",
+          "version": "9.1.6",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@npmcli/arborist": "^9.4.1",
+            "@npmcli/arborist": "^9.4.3",
             "@npmcli/run-script": "^10.0.0",
             "npm-package-arg": "^13.0.0",
             "pacote": "^21.0.2"
@@ -23986,17 +23867,18 @@
           }
         },
         "lru-cache": {
-          "version": "11.2.6",
+          "version": "11.3.5",
           "bundled": true,
           "dev": true
         },
         "make-fetch-happen": {
-          "version": "15.0.4",
+          "version": "15.0.5",
           "bundled": true,
           "dev": true,
           "requires": {
             "@gar/promise-retry": "^1.0.0",
             "@npmcli/agent": "^4.0.0",
+            "@npmcli/redact": "^4.0.0",
             "cacache": "^20.0.1",
             "http-cache-semantics": "^4.1.1",
             "minipass": "^7.0.2",
@@ -24009,11 +23891,11 @@
           }
         },
         "minimatch": {
-          "version": "10.2.4",
+          "version": "10.2.5",
           "bundled": true,
           "dev": true,
           "requires": {
-            "brace-expansion": "^5.0.2"
+            "brace-expansion": "^5.0.5"
           }
         },
         "minipass": {
@@ -24041,26 +23923,11 @@
           }
         },
         "minipass-flush": {
-          "version": "1.0.5",
+          "version": "1.0.6",
           "bundled": true,
           "dev": true,
           "requires": {
-            "minipass": "^3.0.0"
-          },
-          "dependencies": {
-            "minipass": {
-              "version": "3.3.6",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "yallist": "^4.0.0"
-              }
-            },
-            "yallist": {
-              "version": "4.0.0",
-              "bundled": true,
-              "dev": true
-            }
+            "minipass": "^7.1.3"
           }
         },
         "minipass-pipeline": {
@@ -24118,19 +23985,19 @@
           "dev": true
         },
         "node-gyp": {
-          "version": "12.2.0",
+          "version": "12.3.0",
           "bundled": true,
           "dev": true,
           "requires": {
             "env-paths": "^2.2.0",
             "exponential-backoff": "^3.1.1",
             "graceful-fs": "^4.2.6",
-            "make-fetch-happen": "^15.0.0",
             "nopt": "^9.0.0",
             "proc-log": "^6.0.0",
             "semver": "^7.3.5",
             "tar": "^7.5.4",
             "tinyglobby": "^0.2.12",
+            "undici": "^6.25.0",
             "which": "^6.0.0"
           }
         },
@@ -24307,7 +24174,6 @@
         },
         "promise-retry": {
           "version": "2.0.1",
-          "bundled": true,
           "dev": true,
           "requires": {
             "err-code": "^2.0.2",
@@ -24342,7 +24208,6 @@
         },
         "retry": {
           "version": "0.12.0",
-          "bundled": true,
           "dev": true
         },
         "safer-buffer": {
@@ -24431,7 +24296,7 @@
           "dev": true
         },
         "tar": {
-          "version": "7.5.11",
+          "version": "7.5.13",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -24453,12 +24318,12 @@
           "dev": true
         },
         "tinyglobby": {
-          "version": "0.2.15",
+          "version": "0.2.16",
           "bundled": true,
           "dev": true,
           "requires": {
             "fdir": "^6.5.0",
-            "picomatch": "^4.0.3"
+            "picomatch": "^4.0.4"
           },
           "dependencies": {
             "fdir": {
@@ -24468,7 +24333,7 @@
               "requires": {}
             },
             "picomatch": {
-              "version": "4.0.3",
+              "version": "4.0.4",
               "bundled": true,
               "dev": true
             }
@@ -24489,9 +24354,13 @@
             "make-fetch-happen": "^15.0.1"
           }
         },
+        "undici": {
+          "version": "6.25.0",
+          "bundled": true,
+          "dev": true
+        },
         "unique-filename": {
           "version": "5.0.0",
-          "bundled": true,
           "dev": true,
           "requires": {
             "unique-slug": "^6.0.0"
@@ -24499,7 +24368,6 @@
         },
         "unique-slug": {
           "version": "6.0.0",
-          "bundled": true,
           "dev": true,
           "requires": {
             "imurmurhash": "^0.1.4"
@@ -24549,7 +24417,7 @@
       "integrity": "sha512-l7/uyVfEi2e3ho+ovaJZC0xlbwzXNUz3RxkxpfcnLuoGKAuYoo9YoJ/uy18PsTD8IziugGHks4t/mGmBJEZ4Qg==",
       "dev": true,
       "requires": {
-        "got": "^9.6.0",
+        "got": "^12.1.0",
         "is-scoped": "^2.1.0",
         "is-url-superb": "^3.0.0",
         "lodash.zip": "^4.2.0",
@@ -24617,12 +24485,6 @@
         "windows-release": "^3.1.0"
       }
     },
-    "os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
-      "dev": true
-    },
     "ow": {
       "version": "0.15.1",
       "resolved": "https://registry.npmjs.org/ow/-/ow-0.15.1.tgz",
@@ -24641,9 +24503,9 @@
       }
     },
     "p-cancelable": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
-      "integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-3.0.0.tgz",
+      "integrity": "sha512-mlVgR3PGuzlo0MmTdk4cXqXWlwQDLnONTAg6sm62XkMJEiRxN3GL3SffkYvqwonbkJBcrI7Uvv5Zh9yjvn2iUw==",
       "dev": true
     },
     "p-defer": {
@@ -24790,7 +24652,7 @@
       "integrity": "sha512-k3bdm2n25tkyxcjSKzB5x8kfVxlMdgsbPr0GkZcwHsLpba6cBjqCt1KlcChKEvxHIcTB1FVMuwoijZ26xex5MQ==",
       "dev": true,
       "requires": {
-        "got": "^9.6.0",
+        "got": "^12.1.0",
         "registry-auth-token": "^4.0.0",
         "registry-url": "^5.0.0",
         "semver": "^6.2.0"
@@ -24889,9 +24751,9 @@
       "dev": true
     },
     "picomatch": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true
     },
     "pify": {
@@ -24984,12 +24846,6 @@
       "requires": {
         "find-up": "^4.0.0"
       }
-    },
-    "prepend-http": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
-      "integrity": "sha512-ravE6m9Atw9Z/jjttRUZ+clIXogdghyZAuWJ3qEzjT+jI/dL1ifAqhZeC5VHzQp1MSt1+jxKkFNemj/iO7tVUA==",
-      "dev": true
     },
     "prettier": {
       "version": "2.8.2",
@@ -25266,12 +25122,6 @@
         "regenerate": "^1.4.2"
       }
     },
-    "regenerator-runtime": {
-      "version": "0.13.11",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
-      "dev": true
-    },
     "regenerator-transform": {
       "version": "0.15.1",
       "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.15.1.tgz",
@@ -25353,6 +25203,12 @@
         "supports-preserve-symlinks-flag": "^1.0.0"
       }
     },
+    "resolve-alpn": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
+      "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
+      "dev": true
+    },
     "resolve-cwd": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
@@ -25375,12 +25231,12 @@
       "dev": true
     },
     "responselike": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
-      "integrity": "sha512-/Fpe5guzJk1gPqdJLJR5u7eG/gNY4nImjbRDaVWVMRhne55TCmj2i9Q+54PBRfatRC8v/rIiv9BN0pMd9OV5EQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-3.0.0.tgz",
+      "integrity": "sha512-40yHxbNcl2+rzXvZuVkrYohathsSJlMTXKryG5y8uciHv1+xDLHQpgjG64JUO9nrEq2jGLH6IZ8BcZyw3wrweg==",
       "dev": true,
       "requires": {
-        "lowercase-keys": "^1.0.0"
+        "lowercase-keys": "^3.0.0"
       }
     },
     "restore-cursor": {
@@ -25403,14 +25259,12 @@
       }
     },
     "rollup": {
-      "version": "1.32.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.32.1.tgz",
-      "integrity": "sha512-/2HA0Ec70TvQnXdzynFffkjA6XN+1e2pEv/uKS5Ulca40g2L7KuOE3riasHoNVHOsFD5KKZgDsMk1CP3Tw9s+A==",
+      "version": "2.80.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.80.0.tgz",
+      "integrity": "sha512-cIFJOD1DESzpjOBl763Kp1AH7UE/0fcdHe6rZXUdQ9c50uvgigvW97u3IcSeBwOkgqL/PXPBktBCh0KEu5L8XQ==",
       "dev": true,
       "requires": {
-        "@types/estree": "*",
-        "@types/node": "*",
-        "acorn": "^7.1.0"
+        "fsevents": "~2.3.2"
       }
     },
     "rollup-plugin-babel": {
@@ -25709,14 +25563,6 @@
           "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
           "dev": true
         },
-        "typescript": {
-          "version": "5.9.3",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-          "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-          "dev": true,
-          "optional": true,
-          "peer": true
-        },
         "wrap-ansi": {
           "version": "9.0.2",
           "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
@@ -25739,14 +25585,8 @@
             "get-caller-file": "^2.0.5",
             "string-width": "^7.2.0",
             "y18n": "^5.0.5",
-            "yargs-parser": "^22.0.0"
+            "yargs-parser": "^13.1.2"
           }
-        },
-        "yargs-parser": {
-          "version": "22.0.0",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
-          "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
-          "dev": true
         }
       }
     },
@@ -25761,9 +25601,9 @@
       }
     },
     "semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true
     },
     "semver-regex": {
@@ -26329,7 +26169,7 @@
       "dev": true,
       "requires": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "dependencies": {
         "fdir": {
@@ -26338,12 +26178,6 @@
           "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
           "dev": true,
           "requires": {}
-        },
-        "picomatch": {
-          "version": "4.0.4",
-          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-          "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-          "dev": true
         }
       }
     },
@@ -26354,30 +26188,15 @@
       "dev": true
     },
     "tmp": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-      "dev": true,
-      "requires": {
-        "os-tmpdir": "~1.0.2"
-      }
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "dev": true
     },
     "tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
       "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
-      "dev": true
-    },
-    "to-fast-properties": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
-      "dev": true
-    },
-    "to-readable-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
-      "integrity": "sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q==",
       "dev": true
     },
     "to-regex-range": {
@@ -26420,36 +26239,17 @@
         "lodash.memoize": "4.x",
         "make-error": "1.x",
         "semver": "7.x",
-        "yargs-parser": "^21.0.1"
+        "yargs-parser": "^13.1.2"
       },
       "dependencies": {
-        "lru-cache": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-          "dev": true,
-          "requires": {
-            "yallist": "^4.0.0"
-          }
-        },
         "semver": {
-          "version": "7.3.8",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        },
-        "yallist": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "version": "7.7.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+          "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
           "dev": true
         },
         "yargs-parser": {
-          "version": "21.1.1",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+          "version": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
           "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
           "dev": true
         }
@@ -26621,9 +26421,9 @@
           }
         },
         "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "version": "5.7.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+          "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
           "dev": true
         },
         "semver-diff": {
@@ -26642,15 +26442,6 @@
       "resolved": "https://registry.npmjs.org/url-join/-/url-join-5.0.0.tgz",
       "integrity": "sha512-n2huDr9h9yzd6exQVnH/jU5mr+Pfx08LRXXZhkLLetAMESRj+anQsTAh940iMrIetKAmry9coFuZQ2jY8/p3WA==",
       "dev": true
-    },
-    "url-parse-lax": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
-      "integrity": "sha512-NjFKA0DidqPa5ciFcSrXnAltTtzz84ogy+NebPvfEgAck0+TNg4UJ4IN+fB7zRZfbgUf0syOo9MDxFkDSMuFaQ==",
-      "dev": true,
-      "requires": {
-        "prepend-http": "^2.0.0"
-      }
     },
     "url-regex": {
       "version": "5.0.0",
@@ -26790,9 +26581,9 @@
       },
       "dependencies": {
         "cross-spawn": {
-          "version": "6.0.5",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+          "version": "6.0.6",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.6.tgz",
+          "integrity": "sha512-VqCUuhcd1iB+dsv8gxPttb5iZh/D0iubSP21g36KXdEuf6I5JiioesUVjpCdHV9MZRUfVFlvwtIUyPfxo5trtw==",
           "dev": true,
           "requires": {
             "nice-try": "^1.0.4",
@@ -26854,9 +26645,9 @@
           "dev": true
         },
         "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "version": "5.7.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+          "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
           "dev": true
         },
         "shebang-command": {
@@ -26986,12 +26777,11 @@
         "require-directory": "^2.1.1",
         "string-width": "^4.2.3",
         "y18n": "^5.0.5",
-        "yargs-parser": "^21.1.1"
+        "yargs-parser": "^13.1.2"
       },
       "dependencies": {
         "yargs-parser": {
-          "version": "21.1.1",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+          "version": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
           "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
           "dev": true
         }

--- a/package.json
+++ b/package.json
@@ -54,6 +54,14 @@
       ]
     ]
   },
+  "overrides": {
+    "picomatch": "^4.0.4",
+    "tmp": "^0.2.4",
+    "got": "^12.1.0",
+    "yargs-parser": "^13.1.2",
+    "rollup": "^2.80.0",
+    "npm": "^11.13.0"
+  },
   "release": {
     "plugins": [
       "@semantic-release/commit-analyzer",

--- a/package.json
+++ b/package.json
@@ -59,8 +59,7 @@
     "tmp": "^0.2.4",
     "got": "^12.1.0",
     "yargs-parser": "^13.1.2",
-    "rollup": "^2.80.0",
-    "npm": "^11.13.0"
+    "rollup": "^2.80.0"
   },
   "release": {
     "plugins": [


### PR DESCRIPTION
## Summary

Resolves all 7 open Dependabot security alerts by adding `overrides` to `package.json` to force fixed versions of vulnerable transitive dependencies pulled in by build tooling (`@pika/pack`, `np`, `@semantic-release/npm`).

| # | Package | Severity | Resolved version |
|---|---|---|---|
| #11 | yargs-parser | moderate | 13.1.2 |
| #29 | got | moderate | 12.6.1 |
| #50 | rollup | high | 2.80.0 |
| #63 | tmp | low | 0.2.5 |
| #83 | rollup | high | 2.80.0 |
| #84 | minimatch | high | 10.2.5 |
| #104 | picomatch | medium | 4.0.4 |

The `npm` override (`^11.13.0`) is needed because npm bundles its own `tinyglobby/picomatch@4.0.3`; 11.13.0 ships 4.0.4.

No source code changes; build tooling versions in `devDependencies` are unchanged (avoiding the breaking-change downgrade `npm audit fix --force` would have applied to `@pika/pack`).

## Test plan

- [x] `npm test` passes (15 tests, 100% statement/branch/function/line coverage)
- [x] `npm run lint` passes
- [ ] CI green on this PR